### PR TITLE
Rename to NamespaceExportDeclaration from GlobalModuleExportDeclaration

### DIFF
--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -165,9 +165,8 @@ export function getTypingInfo(directory: string): TypingParseFailResult | Typing
 
 		src.getChildren()[0].getChildren().forEach(node => {
 			switch (node.kind) {
-				// TODO: Rename to NamespaceExportDeclaration when upstream compiler updates
-				case ts.SyntaxKind.GlobalModuleExportDeclaration:
-					const globalName = (node as ts.GlobalModuleExportDeclaration).name.getText();
+				case ts.SyntaxKind.NamespaceExportDeclaration:
+					const globalName = (node as ts.NamespaceExportDeclaration).name.getText();
 					log.push(`Found UMD module declaration for global \`${globalName}\``);
 					// Don't set hasGlobalDeclarations = true even though we add a symbol here
 					// since this is still a legal module-only declaration


### PR DESCRIPTION
I get an error like the following when I try to build this now
```
src/lib/definition-parser.ts(169,24): error TS2339: Property 'GlobalModuleExportDeclaration' does not exist on type 'typeof SyntaxKind'.
src/lib/definition-parser.ts(170,37): error TS2305: Module 'ts' has no exported member 'GlobalModuleExportDeclaration'.
```

I think the `NamespaceExportDeclaration` is ready by https://github.com/Microsoft/TypeScript/pull/8678. Here is the version of the `tsc` that is installed by `npm install` automatically following the semver:
```
node_modules/typescript/bin/tsc -v
Version 1.9.0-dev.20160601-1.0
```