### PR TITLE
Fix big where version could be parsed across multiple lines

### DIFF
--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -322,8 +322,8 @@ export async function getTypingInfo(directory: string): Promise<TypingParseFailR
 	}
 
 	const authors = regexMatch(/^\/\/ Definitions by: (.+)$/m, "Unknown");
-	const libraryMajorVersion = regexMatch(/^\/\/ Type definitions for \D+ v?(\d+)/m, "0");
-	const libraryMinorVersion = regexMatch(/^\/\/ Type definitions for \D+ v?\d+\.(\d+)/m, "0");
+	const libraryMajorVersion = regexMatch(/^\/\/ Type definitions for \D+ v?(\d+)$/m, "0");
+	const libraryMinorVersion = regexMatch(/^\/\/ Type definitions for \D+ v?\d+\.(\d+)$/m, "0");
 	// const libraryName = regexMatch(/^\/\/ Type definitions for ([^\s]+)/m, "Unknown").trim();
 	const libraryName = regexMatch(/^\/\/ Type definitions for (.+)$/m, "Unknown").trim();
 	const projectName = regexMatch(/^\/\/ Project: (.+)$/m, "");


### PR DESCRIPTION
This was causing `mz` to have a version of `0777`.