### PR TITLE
Normalize line endings so content hash is the same on linux and windows

### DIFF
--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -238,7 +238,7 @@ export function readNotNeededPackages(): NotNeededPackage[] {
 
 export function computeHash(content: string) {
 	// Normalize line endings
-	content = content.replace(/\r\n/g, "\n");
+	content = content.replace(/\r\n?/g, "\n");
 
 	const h = crypto.createHash("sha256");
 	h.update(content, "utf-8");

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -237,6 +237,9 @@ export function readNotNeededPackages(): NotNeededPackage[] {
 }
 
 export function computeHash(content: string) {
+	// Normalize line endings
+	content = content.replace(/\r\n/g, "\n");
+
 	const h = crypto.createHash("sha256");
 	h.update(content, "utf-8");
 	return <string> h.digest("hex");


### PR DESCRIPTION
Since this makes us need to republish everything (current content hashes were computed with `\r\n`), I want to get this in before removing the `alpha` tag and publishing all.