### PR TITLE
Error on self-referencing package

### DIFF
--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -334,6 +334,10 @@ export async function getTypingInfo(directory: string): Promise<TypingParseFailR
 	const fileContents = await mapAsyncOrdered(declFiles, async d => d + "**" + await readFile(d));
 	const allContent = fileContents.join("||");
 
+	if (libraryName !== "node-schedule" && (referencedLibraries.concat(moduleDependencies).some(s => s === libraryName))) {
+		throw new Error(`Package references itself: ${libraryName}`);
+	}
+
 	return {
 		log,
 		warnings,

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -334,7 +334,7 @@ export async function getTypingInfo(directory: string): Promise<TypingParseFailR
 	const fileContents = await mapAsyncOrdered(declFiles, async d => d + "**" + await readFile(d));
 	const allContent = fileContents.join("||");
 
-	if (libraryName !== "node-schedule" && (referencedLibraries.concat(moduleDependencies).some(s => s === libraryName))) {
+	if (referencedLibraries.concat(moduleDependencies).some(s => s === libraryName)) {
 		throw new Error(`Package references itself: ${libraryName}`);
 	}
 


### PR DESCRIPTION
This should eventually be replaced by something in `definition-tester`. @rakatyal