### PR TITLE
Don't need `search-index-full.json` and `search-index-head.json`, so don't generate them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,22 +192,18 @@ This argument may be needed during development,
 
 > `node bin/create-search-index.js`
 
-This script creates several data files useful for offering fast search of types data.
+This script creates `data/search-index-min.json`, which (in the upload step) will be uploaded to Azure and used by [TypeSearch](https://github.com/microsoft/typesearch).
 This step is not necessary for other steps in the process.
 
 ### Arguments to `create-search-index`
 
-By default, this script fetches download counts from NPM for use in search result ranking.
+You can generate a prettier output in `data/search-index-full.json`.
+This version is for human review only and is not compatible with TypeSearch.
+
+By default, `create-search-index` fetches download counts from NPM for use in search result ranking.
 The argument `--skipDownloads` disables this behavior.
 
-### Outputs of `create-search-index`
-
-This script generates the following files
- * `data/search-index-full.json`: An unminified index useful for searching
- * `data/search-index-min.json`: A minified index useful for searching
- * `data/search-index-head.json`: A minified index of the top 100 most-downloaded packages
-
-### Minified and Unminified Search Entries
+### Search Entries
 
 Each `search-*.json` file consists of an array.
 An example unminified entry is:
@@ -231,13 +227,7 @@ If `--skipDownloads` was specified, `downloads` will be -1.
 In the case where the type package name is different from the NPM package name,
   or no NPM package name exists, `downloads` will be 0.
 
-In the minified files, the properties are simply renamed:
- * `typePackageName` is `t`
- * `globals` is `g`
- * `declaredExternalModules` is `m`
- * `projectName` is `p`
- * `libraryName` is `l`
- * `downlaods` is `d`
+In the minified files, the properties are simply renamed. See `src/lib/search-index-generator.ts` for documentation.
 
 Empty arrays may be elided in future versions of the minified files.
 

--- a/src/create-search-index.ts
+++ b/src/create-search-index.ts
@@ -1,30 +1,51 @@
 import * as yargs from "yargs";
 import { AnyPackage, existsTypesDataFile, readNotNeededPackages, readTypings, writeDataFile } from "./lib/common";
 import { done, nAtATime } from "./lib/util";
-import { createSearchRecord, minifySearchRecord } from "./lib/search-index-generator";
+import { createSearchRecord, SearchRecord } from "./lib/search-index-generator";
 
 if (!module.parent) {
 	if (!existsTypesDataFile()) {
 		console.log("Run parse-definitions first!");
 	} else {
 		const skipDownloads = yargs.argv.skipDownloads;
-		done(main(skipDownloads));
+		const full = yargs.argv.full;
+		done(main(skipDownloads, full));
 	}
 }
 
-export default async function main(skipDownloads: boolean): Promise<void> {
+export default async function main(skipDownloads: boolean, full: boolean): Promise<void> {
 	let packages = (readTypings() as AnyPackage[]).concat(readNotNeededPackages());
 	console.log(`Loaded ${packages.length} entries`);
 
 	const records = await nAtATime(100, packages, pkg => createSearchRecord(pkg, skipDownloads));
 	// Most downloads first
-	records.sort((a, b) => b.downloads - a.downloads);
+	records.sort((a, b) => b.d - a.d);
 
 	console.log(`Done generating search index`);
-	const minRecords = records.map(minifySearchRecord);
 
 	console.log(`Writing out data files`);
-	writeDataFile("search-index-full.json", records);
-	writeDataFile("search-index-min.json", minRecords, false);
-	writeDataFile("search-index-head.json", minRecords.slice(0, 100), false);
+	writeDataFile("search-index-min.json", records, false);
+	if (full) {
+		writeDataFile("search-index-full.json", records.map(verboseRecord), true);
+	}
+}
+
+function verboseRecord(r: SearchRecord): {} {
+	return renameProperties(r, {
+		t: "typePackageName",
+		g: "globals",
+		m: "declaredExternalModules",
+		p: "projectName",
+		l: "libraryName",
+		d: "downloads",
+		r: "redirect"
+	});
+}
+
+function renameProperties(obj: {}, replacers: { [name: string]: string }): {} {
+	const out: any = {};
+	for (const key of Object.getOwnPropertyNames(obj)) {
+		out[replacers[key]] = (<any> obj)[key];
+	}
+	return out;
 }

--- a/src/full.ts
+++ b/src/full.ts
@@ -24,7 +24,7 @@ export default async function full(client: NpmClient, dry: boolean, timeStamp: s
 	checkParseResults();
 	await calculateVersions(/*forceUpdate*/ false);
 	await generatePackages();
-	await createSearchIndex(/*skipDownloads*/ false);
+	await createSearchIndex(/*skipDownloads*/ false, /*full*/ false);
 	await publishPackages(client, dry);
 	if (!dry) {
 		await uploadBlobs(timeStamp);

--- a/src/lib/search-index-generator.ts
+++ b/src/lib/search-index-generator.ts
@@ -4,22 +4,6 @@ import fetch = require("node-fetch");
 
 export interface SearchRecord {
 	// types package name
-	typePackageName: string;
-	// globals
-	globals: string[];
-	// modules
-	declaredExternalModules: string[];
-	// project name
-	projectName: string;
-	// library name
-	libraryName: string;
-	// downloads in the last month from NPM
-	downloads: number;
-	redirect?: string;
-}
-
-export interface MinifiedSearchRecord {
-	// types package name
 	t: string;
 	// globals
 	g: string[];
@@ -35,27 +19,15 @@ export interface MinifiedSearchRecord {
 	r: string;
 }
 
-export function minifySearchRecord(data: SearchRecord): MinifiedSearchRecord {
-	return {
-		t: data.typePackageName,
-		g: data.globals,
-		m: data.declaredExternalModules,
-		p: data.projectName,
-		l: data.libraryName,
-		d: data.downloads,
-		r: data.redirect
-	};
-}
-
 export async function createSearchRecord(info: AnyPackage, skipDownloads: boolean): Promise<SearchRecord> {
 	return {
-		projectName: info.projectName,
-		libraryName: info.libraryName,
-		globals: info.globals,
-		typePackageName: info.typingsPackageName,
-		declaredExternalModules: info.declaredModules,
-		downloads: await getDownloads(),
-		redirect: info.packageKind === "not-needed" ? info.sourceRepoURL : undefined
+		p: info.projectName,
+		l: info.libraryName,
+		g: info.globals,
+		t: info.typingsPackageName,
+		m: info.declaredModules,
+		d: await getDownloads(),
+		r: info.packageKind === "not-needed" ? info.sourceRepoURL : undefined
 	};
 
 	async function getDownloads(): Promise<number> {


### PR DESCRIPTION
Depends on Microsoft/TypeSearch#13
The files would also have to be manually deleted from Azure.