### PR TITLE
Increase size of IIS stored logs

### DIFF
--- a/IISNode.yml
+++ b/IISNode.yml
@@ -1,2 +1,5 @@
+# For all options see https://github.com/tjanczuk/iisnode/blob/master/src/samples/configuration/iisnode.yml
 loggingEnabled: true
 devErrorsEnabled: false
+maxLogFileSizeInKB: 2048
+maxTotalLogFileSizeInKB: 16384


### PR DESCRIPTION
This is necessary after #111 - single runs of `full` are taking up many log files because of all the output from the parser and generator.