### PR TITLE
Add script to fix all non-gzipped packages

### DIFF
--- a/src/calculate-versions.ts
+++ b/src/calculate-versions.ts
@@ -1,14 +1,17 @@
+import * as child_process from "child_process";
+import * as https from "https";
 import * as yargs from "yargs";
-import { existsTypesDataFileSync, readTypings } from "./lib/common";
+import { existsTypesDataFileSync, fullPackageName, readTypings } from "./lib/common";
 import Versions, { Changes, writeChanges } from "./lib/versions";
-import { done } from "./lib/util";
+import { done, streamPromise, unGzip } from "./lib/util";
 
 if (!module.parent) {
 	if (!existsTypesDataFileSync()) {
 		console.log("Run parse-definitions first!");
 	} else {
 		const forceUpdate = yargs.argv.forceUpdate;
-		done(main(forceUpdate));
+		//done(main(forceUpdate));
+		done(fixNotGzipped());
 	}
 }
 
@@ -24,4 +27,68 @@ export default async function main(forceUpdate: boolean): Promise<void> {
 	}
 	await versions.saveLocally();
 	await writeChanges(changes);
+}
+
+async function fixNotGzipped() {
+	const versions = await Versions.loadFromBlob();
+	const changes: Changes = [];
+
+	for (const typing of await readTypings()) {
+		console.log(typing.typingsPackageName);
+		if (!(await isGzipped(typing.typingsPackageName))) {
+			versions.recordUpdate(typing, /*forceUpdate*/true);
+			console.log(`Force update of ${typing.typingsPackageName}, not gzipped`);
+			changes.push(typing.typingsPackageName);
+		}
+	}
+
+	await versions.saveLocally();
+	await writeChanges(changes);
+}
+
+async function isGzipped(packageName: string): Promise<boolean> {
+	const {shasum, tarball} = await fetchInfo(packageName);
+	const tgz = await fetchStream(tarball);
+	const unGzipper = unGzip(tgz);
+	unGzipper.on("data", (chunk: any) => {
+		(<any> tgz).destroy();
+	});
+	try {
+		await streamPromise(unGzipper);
+		return true;
+	}
+	catch (error) {
+		// If there's an error when trying to unzip it, that's probably because it wasn't zipped in the first place.
+		return false;
+	}
+}
+
+function fetchStream(url: string): Promise<NodeJS.ReadableStream> {
+	return new Promise(resolve => {
+		https.get(url, resolve);
+	});
+}
+
+interface Info {
+	shasum: string;
+	tarball: string;
+}
+
+async function fetchInfo(packageName: string): Promise<Info> {
+	return new Promise<Info>((resolve, reject) => {
+		child_process.exec(`npm info ${fullPackageName(packageName)}`, { encoding: "utf8" }, (err, stdout) => {
+			if (err) {
+				reject(err);
+			}
+			else {
+				resolve(getDistSectionOfNpmInfo(stdout));
+			}
+		});
+	});
+}
+
+function getDistSectionOfNpmInfo(info: string): Info {
+	const match = /\{ shasum: '(\w+)',\s*tarball: '([^']+)' \}/m.exec(info);
+	const [shasum, tarball] = match.slice(1);
+	return {shasum, tarball};
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -124,13 +124,18 @@ export function streamOfString(text: string): NodeJS.ReadableStream {
 	return s;
 }
 
-export function stringOfStream(stream: NodeJS.ReadableStream): Promise<string> {
+export async function stringOfStream(stream: NodeJS.ReadableStream): Promise<string> {
 	let body = "";
 	stream.on("data", (data: Buffer) => {
 		body += data.toString("utf8");
 	});
+	await streamPromise(stream);
+	return body;
+}
+
+export function streamPromise(stream: NodeJS.ReadableStream): Promise<void> {
 	return new Promise((resolve, reject) => {
 		stream.on("error", reject);
-		stream.on("end", () => resolve(body));
+		stream.on("end", resolve);
 	});
 }

--- a/src/publish-packages.ts
+++ b/src/publish-packages.ts
@@ -1,10 +1,12 @@
+import * as child_process from "child_process";
 import * as fs from "fs";
+import * as https from "https";
 import * as yargs from "yargs";
-import { AnyPackage, existsTypesDataFileSync, readAllPackages } from "./lib/common";
+import { AnyPackage, existsTypesDataFileSync, fullPackageName, readAllPackages } from "./lib/common";
 import { LogWithErrors, logger, writeLog } from "./lib/logging";
 import NpmClient from "./lib/npm-client";
 import * as publisher from "./lib/package-publisher";
-import { done, nAtATime } from "./lib/util";
+import { done, filterAsyncOrdered, nAtATime, streamPromise, unGzip } from "./lib/util";
 
 if (!module.parent) {
 	if (!existsTypesDataFileSync() || !fs.existsSync("./output") || fs.readdirSync("./output").length === 0) {
@@ -12,12 +14,13 @@ if (!module.parent) {
 	}
 	else {
 		const dry = !!yargs.argv.dry;
+		const fix = !!yargs.argv.fix;
 		const singleName = yargs.argv.single;
 		// For testing only. Do not use on real @types repo.
 		const shouldUnpublish = !!yargs.argv.unpublish;
 
-		if (singleName && shouldUnpublish) {
-			throw new Error("Selet only one --single=foo or --shouldUnpublish");
+		if (fix + singleName + shouldUnpublish > 1) {
+			throw new Error("Select only one of --fix or -single=foo or --shouldUnpublish");
 		}
 
 		done(go());
@@ -28,7 +31,10 @@ if (!module.parent) {
 			}
 			else {
 				const client = await NpmClient.create();
-				if (singleName) {
+				if (fix) {
+					await republishToFixNotGzipped(client, dry);
+				}
+				else if (singleName) {
 					await single(client, singleName, dry);
 				}
 				else {
@@ -95,4 +101,67 @@ async function unpublish(dry: boolean): Promise<void> {
 	for (const pkg of await readAllPackages()) {
 		await publisher.unpublishPackage(pkg, dry);
 	}
+}
+
+async function republishToFixNotGzipped(client: NpmClient, dry: boolean): Promise<void> {
+	for (const pkg of await readAllPackages()) {
+		const name = pkg.typingsPackageName;
+		if (await isGzipped(name)) {
+			console.log(`${name} is OK`);
+		}
+		else {
+			console.log(`${name} needs republish`);
+			const publishLog = await publisher.publishPackage(client, pkg, dry);
+			for (const log of publishLog) {
+				console.log(log);
+			}
+		}
+	}
+}
+
+async function isGzipped(packageName: string): Promise<boolean> {
+	const {shasum, tarball} = await fetchInfo(packageName);
+	const tgz = await fetchStream(tarball);
+	const unGzipper = unGzip(tgz);
+	unGzipper.on("data", (chunk: any) => {
+		(<any> tgz).destroy();
+	});
+	try {
+		await streamPromise(unGzipper);
+		return true;
+	}
+	catch (error) {
+		// If there's an error when trying to unzip it, that's probably because it wasn't zipped in the first place.
+		return false;
+	}
+}
+
+function fetchStream(url: string): Promise<NodeJS.ReadableStream> {
+	return new Promise(resolve => {
+		https.get(url, resolve);
+	});
+}
+
+interface Info {
+	shasum: string;
+	tarball: string;
+}
+
+async function fetchInfo(packageName: string): Promise<Info> {
+	return new Promise<Info>((resolve, reject) => {
+		child_process.exec(`npm info ${fullPackageName(packageName)}`, { encoding: "utf8" }, (err, stdout) => {
+			if (err) {
+				reject(err);
+			}
+			else {
+				resolve(getDistSectionOfNpmInfo(stdout));
+			}
+		});
+	});
+}
+
+function getDistSectionOfNpmInfo(info: string): Info {
+	const match = /\{ shasum: '(\w+)',\s*tarball: '([^']+)' \}/m.exec(info);
+	const [shasum, tarball] = match.slice(1);
+	return {shasum, tarball};
 }


### PR DESCRIPTION
We always gzip as of #104 but some packages are still non-gzipped. This would republish them.
Running this requires using the `--forceUpdate` option during `calculate-versions`.
This doesn't necessarily need to be merged, since it only needs to be run once.
Should fix DefinitelyTyped/DefinitelyTyped#10508 and DefinitelyTyped/DefinitelyTyped#10506.