### PR TITLE
Add script to fix all packages whose README has not been uploaded

### DIFF
--- a/src/calculate-versions.ts
+++ b/src/calculate-versions.ts
@@ -1,5 +1,6 @@
+import * as child_process from "child_process";
 import * as yargs from "yargs";
-import { existsTypesDataFileSync, readTypings } from "./lib/common";
+import { existsTypesDataFileSync, fullPackageName, readTypings } from "./lib/common";
 import Versions, { Changes, writeChanges } from "./lib/versions";
 import { done } from "./lib/util";
 
@@ -8,7 +9,8 @@ if (!module.parent) {
 		console.log("Run parse-definitions first!");
 	} else {
 		const forceUpdate = yargs.argv.forceUpdate;
-		done(main(forceUpdate));
+		//done(main(forceUpdate));
+		done(fixNotReadme());
 	}
 }
 
@@ -24,4 +26,37 @@ export default async function main(forceUpdate: boolean): Promise<void> {
 	}
 	await versions.saveLocally();
 	await writeChanges(changes);
+}
+
+export async function fixNotReadme() {
+	const versions = await Versions.loadFromBlob();
+	const changes: Changes = [];
+
+	for (const typing of await readTypings()) {
+		console.log(typing.typingsPackageName);
+		if (!(await hasReadme(typing.typingsPackageName))) {
+			versions.recordUpdate(typing, /*forceUpdate*/true);
+			console.log(`Force update of ${typing.typingsPackageName}, which has no README`);
+		}
+	}
+
+	await versions.saveLocally();
+	await writeChanges(changes);
+}
+
+async function hasReadme(packageName: string): Promise<boolean> {
+	return (await fetchReadme(packageName)).trim().length > 0;
+}
+
+async function fetchReadme(packageName: string): Promise<string> {
+	return new Promise<string>((resolve, reject) => {
+		child_process.exec(`npm info ${fullPackageName(packageName)} readme`, { encoding: "utf8" }, (err, stdout) => {
+			if (err) {
+				reject(err);
+			}
+			else {
+				resolve(stdout);
+			}
+		});
+	});
 }

--- a/src/get-definitely-typed.ts
+++ b/src/get-definitely-typed.ts
@@ -20,6 +20,7 @@ async function getRepo(): Promise<Repository> {
 	else {
 		const repo = await Clone(settings.sourceRepository, settings.definitelyTypedPath);
 		await repo.checkoutBranch(settings.sourceBranch);
+		return repo;
 	}
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"include": ["src"],
+	"include": ["src/**/*.ts"],
 	"compilerOptions": {
 		"module": "commonjs",
 		"noImplicitAny": true,


### PR DESCRIPTION
#122 fixes future publishes, but we still have many packages uploaded with no README. This would fix that, just like #116 did for non-gzipped packages. The method is the same: detect the problem by querying npm, and force-update the version of any package that shows the problem.