### PR TITLE
Store content hash in published package.json

### DIFF
--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -26,7 +26,7 @@ export default class Versions {
 	}
 
 	recordUpdate(typing: TypingsData, forceUpdate: boolean): boolean {
-		const {lastVersion, lastContentHash} = this.getLastVersionAndContentHash(typing);
+		const {lastVersion, lastContentHash} = this.versionInfo(typing);
 		const shouldIncrement = forceUpdate || lastContentHash !== typing.contentHash;
 		if (shouldIncrement) {
 			const key = typing.typingsPackageName;
@@ -36,11 +36,7 @@ export default class Versions {
 		return shouldIncrement;
 	}
 
-	getVersion(typing: TypingsData): number {
-		return this.getLastVersionAndContentHash(typing).lastVersion;
-	}
-
-	private getLastVersionAndContentHash(typing: TypingsData): { lastVersion: number, lastContentHash: string } {
+	versionInfo(typing: TypingsData): { lastVersion: number, lastContentHash: string } {
 		return this.data[typing.typingsPackageName] || { lastVersion: 0, lastContentHash: "" };
 	}
 
@@ -60,9 +56,11 @@ export function writeChanges(changes: Changes): Promise<void> {
 	return writeFile(changesFilename, changes.join("\n"));
 }
 
+export interface VersionInfo {
+	lastVersion: number;
+	lastContentHash: string;
+}
+
 interface VersionMap {
-	[typingsPackageName: string]: {
-		lastVersion: number;
-		lastContentHash: string;
-	};
+	[typingsPackageName: string]: VersionInfo;
 }


### PR DESCRIPTION
What would we ever do if our `versions.json` blob was corrupted or went missing?
This PR would have us start uploading the DefinitelyTyped content hash along with npm packages.

However, NPM already stores a "shasum" along with each package, so if need be, we could calculate the sha of our generated .tgz of of the package and compare it to what's online.
That would be slower, since it requires generating a tgz first rather than just getting the sha of the content on DefinitelyTyped, but this would hopefully be a rare circumstance anyway.

Is this a good idea to merge?