### PR TITLE
Fix azure-storage version to "1.2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Publish DefinitelyTyped definitions to NPM",
   "main": "index.js",
   "dependencies": {
-    "azure-storage": "^1.1.0",
+    "azure-storage": "1.2.0",
     "buffer-equals-constant": "^1.0.0",
     "fs-promise": "^0.5.0",
     "fstream": "^1.0.10",


### PR DESCRIPTION
...because the newest version includes its own typings which override those in declarations.d.ts.