### PR TITLE
An inferred dependency will always use the latest version

### DIFF
--- a/src/lib/package-generator.ts
+++ b/src/lib/package-generator.ts
@@ -107,7 +107,7 @@ async function createPackageJSON(typing: TypingsData, version: number, available
 	}
 
 	const dependencies = pkg.dependencies || {};
-	addInferredDependencies(dependencies, typing, availableTypes, version);
+	addInferredDependencies(dependencies, typing, availableTypes);
 
 	const description = pkg.description || `TypeScript definitions for ${typing.libraryName}`;
 
@@ -135,24 +135,15 @@ async function createPackageJSON(typing: TypingsData, version: number, available
 	return JSON.stringify(out, undefined, 4);
 }
 
-function addInferredDependencies(dependencies: { [name: string]: string }, typing: TypingsData, availableTypes: { [name: string]: TypingsData }, version: number): void {
-	function addDependency(d: string): void {
-		if (dependencies.hasOwnProperty(d) || !availableTypes.hasOwnProperty(d)) {
-			// 1st case: don't add a dependency if it was specified in the package.json or if it has already been added.
+function addInferredDependencies(dependencies: { [name: string]: string }, typing: TypingsData, availableTypes: { [name: string]: TypingsData }): void {
+	function addDependency(depdendency: string): void {
+		if (!Object.prototype.hasOwnProperty.call(dependencies, depdendency) && availableTypes.hasOwnProperty(depdendency)) {
+			// 1st case: Don't add a dependency if it was specified in the package.json or if it has already been added.
 			// 2nd case: If it's not a package we know of, just ignore it.
 			// For example, we may have an import of "http", where the package is depending on "node" to provide that.
-			return;
+			dependencies[fullPackageName(depdendency)] = "latest";
+			// To use a non-latest version, that version must be made explicit in the partial package.json from a DefinitelyTyped directory.
 		}
-
-		const type = availableTypes[d];
-		// In normal releases, we want to allow patch updates, so we use `foo.bar.*`.
-		// In a prerelease, we can only reference *exact* packages.
-		// See https://github.com/npm/node-semver#prerelease-tags
-		const patch = settings.prereleaseTag ?
-			`${version}-${settings.prereleaseTag}` :
-			"*";
-		const semver = `${type.libraryMajorVersion}.${type.libraryMinorVersion}.${patch}`;
-		dependencies[fullPackageName(d)] = semver;
 	}
 	typing.moduleDependencies.forEach(addDependency);
 	typing.libraryDependencies.forEach(addDependency);

--- a/src/lib/package-generator.ts
+++ b/src/lib/package-generator.ts
@@ -142,7 +142,7 @@ function addInferredDependencies(dependencies: { [name: string]: string }, typin
 			// 1st case: Don't add a dependency if it was specified in the package.json or if it has already been added.
 			// 2nd case: If it's not a package we know of, just ignore it.
 			// For example, we may have an import of "http", where the package is depending on "node" to provide that.
-			dependencies[fullPackageName(depdendency)] = "latest";
+			dependencies[fullPackageName(depdendency)] = "*";
 			// To use a non-latest version, that version must be made explicit in the partial package.json from a DefinitelyTyped directory.
 		}
 	}


### PR DESCRIPTION
Fixes Microsoft/TypeScript#10664

What you do think about using `""` instead of `latest`? This would indicate potential compatibility with non-latest versions.
Of course, that might not always be true that it will be compatible with non-latest versions.
But, we of course can't guarantee upon publishing a package that it will forever be compatible with the latest versions of everything else. Using `""` would install the latest by default but allow a user to specify a non-latest version of a dependency in their own `package.json` if that's the version they prefer, and our package would be compatible with that.
