### PR TITLE
Reduce parallelism to avoid overloading npm.

### DIFF
--- a/src/create-search-index.ts
+++ b/src/create-search-index.ts
@@ -17,7 +17,7 @@ export default async function main(skipDownloads: boolean, full: boolean): Promi
 	let packages = await readAllPackages();
 	console.log(`Loaded ${packages.length} entries`);
 
-	const records = await nAtATime(100, packages, pkg => createSearchRecord(pkg, skipDownloads));
+	const records = await nAtATime(25, packages, pkg => createSearchRecord(pkg, skipDownloads));
 	// Most downloads first
 	records.sort((a, b) => b.d - a.d);
 

--- a/src/lib/package-generator.ts
+++ b/src/lib/package-generator.ts
@@ -102,7 +102,8 @@ async function createPackageJSON(typing: TypingsData, { version, contentHash }: 
 	let pkg: PartialPackageJson = typing.hasPackageJson ? await readJson(pkgPath) : {};
 
 	const ignoredField = Object.keys(pkg).find(field => !["dependencies", "description"].includes(field));
-	if (ignoredField) {
+	// Kludge: ignore "scripts" (See https://github.com/DefinitelyTyped/definition-tester/issues/35)
+	if (ignoredField && ignoredField !== "scripts") {
 		throw new Error(`Ignored field in ${pkgPath}: ${ignoredField}`);
 	}
 

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -20,7 +20,7 @@ export default class Versions {
 	static async determineFromNpm(packages: TypingsData[], log: Logger, forceUpdate: boolean): Promise<{changes: Changes, versions: Versions}> {
 		const changes: Changes = [];
 		const data: VersionMap = {};
-		await nAtATime(100, packages, async pkg => {
+		await nAtATime(25, packages, async pkg => {
 			const packageName = pkg.typingsPackageName;
 			let { version, contentHash } = await fetchVersionInfoFromNpm(packageName);
 			if (forceUpdate || pkg.contentHash !== contentHash) {


### PR DESCRIPTION
We were getting `FetchError` in production (both `ETIMEDOUT` and `ECONNRESET`).
Also, allow "scripts" to appear in `package.json` and be ignored.