### PR TITLE
Always use forward slashes in files

### DIFF
--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 
 import { RejectionReason, TypingsData, computeHash, definitelyTypedPath, settings } from "./common";
 import { Logger, LoggerWithErrors, LogWithErrors, quietLoggerWithErrors } from "./logging";
-import { mapAsyncOrdered, readdirRecursive, readFile as readFileText, stripQuotes } from "./util";
+import { mapAsyncOrdered, normalizeSlashes, readdirRecursive, readFile as readFileText, stripQuotes } from "./util";
 
 export interface TypingParseFailResult {
 	kind: "fail";
@@ -278,7 +278,7 @@ function referencedFiles(src: ts.SourceFile, subDirectory: string): string[] {
 		const full = path.normalize(path.join(subDirectory, ref));
 		// If the *normalized* path starts with "..", then it reaches outside of srcDirectory.
 		if (!full.startsWith("..")) {
-			out.push(full);
+			out.push(normalizeSlashes(full));
 		}
 	}
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -53,7 +53,7 @@ export function readdirRecursive(dirPath: string, keepIf: (file: string, stats: 
 	function relativePath(file: string): string {
 		const prefix = dirPath + path.sep;
 		assert(file.startsWith(prefix));
-		return file.slice(prefix.length);
+		return normalizeSlashes(file.slice(prefix.length));
 	}
 	function ignoreRelative(file: string, stats: Stats): boolean {
 		return !keepIf(relativePath(file), stats);
@@ -147,4 +147,8 @@ function initArray<T>(length: number, makeElement: () => T): T[] {
 		arr[i] = makeElement();
 	}
 	return arr;
+}
+
+export function normalizeSlashes(path: string): string {
+	return path.replace(/\\/g, "/");
 }


### PR DESCRIPTION
This makes hash consistent on windows and linux.
(We remembered to do this for line endings in #62, but forgot about slashes.)

The `amplitude-js`, `history`, `react-router`, `react-widgets`, and `redux-router` packages are affected by this change.