### PR TITLE
Use builtin `crypto.timingSafeEqual`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the source code for the types-publisher service, which publishes the contents of [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) to npm.
 
-# Disclaimer  
+# Disclaimer
 
 If there's functionality from the project you'd like to use, please file an issue detailing that. The script isn't intended for public consumption (i.e. we will break the API whenever convenient for us).
 
@@ -341,10 +341,10 @@ The script `npm run make-server-run` will trigger the local webhook just like Gi
 # Using the webhook
 
 ```sh
-npm run webhook
+npm run webhook-dry
 ```
 
-This requires the `GITHUB_SECRET` and `GITHUB_ACCESS_TOKEN` environment variables to be set; see the "Environment variables" section.
+This requires the `GITHUB_SECRET`, `GITHUB_ACCESS_TOKEN`, and `PORT` environment variables to be set; see the "Environment variables" section.
 
 # Settings
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "dependencies": {
     "azure-storage": "1.2.0",
-    "buffer-equals-constant": "^1.0.0",
     "fs-promise": "^0.5.0",
     "fstream": "^1.0.10",
     "longjohn": "^0.2.11",
@@ -45,6 +44,7 @@
     "full": "node bin/full.js",
     "full-dry": "node bin/full.js --dry",
     "lint": "node node_modules/tslint/bin/tslint src/*.ts src/*/*.ts",
+    "webhook-dry": "node ./bin/webhook.js --dry",
     "make-server-run": "node bin/make-server-run.js",
     "make-production-server-run": "node bin/make-server-run.js --remote"
   },
@@ -58,7 +58,7 @@
     "url": "https://github.com/Microsoft/types-publisher/issues"
   },
   "engines": {
-    "node": "^6.2.2"
+    "node": "^6.7.0"
   },
   "homepage": "https://github.com/Microsoft/types-publisher#readme"
 }

--- a/src/lib/declarations.d.ts
+++ b/src/lib/declarations.d.ts
@@ -43,11 +43,6 @@ declare module "npm-registry-client" {
 	export = RegClient;
 }
 
-declare module "buffer-equals-constant" {
-	function f(a: Buffer, b: Buffer): boolean;
-	export = f;
-}
-
 declare module "fs-promise" {
 	export function emptyDir(dirPath: string): Promise<void>
 	export function ensureDir(dirPath: string): Promise<void>;

--- a/src/lib/webhook-server.ts
+++ b/src/lib/webhook-server.ts
@@ -152,12 +152,14 @@ function checkSignature(key: string, data: string, headers: any, log: LoggerWith
 	log.error(`Data is: ${data}`);
 	log.error("");
 	return false;
+}
 
-	// Use a constant-time compare to prevent timing attacks
-	function stringEqualsConstantTime(s1: string, s2: string): boolean {
-		// `timingSafeEqual` throws if they don't have the same length.
-		return s1.length === s2.length && timingSafeEqual(new Buffer(s1), new Buffer(s2));
-	}
+// Use a constant-time compare to prevent timing attacks
+function stringEqualsConstantTime(actual: string, expected: string): boolean {
+	// `timingSafeEqual` throws if they don't have the same length.
+	const actualBuffer = new Buffer(expected.length);
+	actualBuffer.write(actual);
+	return timingSafeEqual(actualBuffer, new Buffer(expected));
 }
 
 export function expectedSignature(key: string, data: string): string {

--- a/src/lib/webhook-server.ts
+++ b/src/lib/webhook-server.ts
@@ -1,5 +1,4 @@
-import bufferEqualsConstantTime = require("buffer-equals-constant");
-import { createHmac } from "crypto";
+import { createHmac, timingSafeEqual } from "crypto";
 import { createServer, IncomingMessage, Server, ServerResponse } from "http";
 import full from "../full";
 import RollingLogs from "./rolling-logs";
@@ -156,7 +155,8 @@ function checkSignature(key: string, data: string, headers: any, log: LoggerWith
 
 	// Use a constant-time compare to prevent timing attacks
 	function stringEqualsConstantTime(s1: string, s2: string): boolean {
-		return bufferEqualsConstantTime(new Buffer(s1), new Buffer(s2));
+		// `timingSafeEqual` throws if they don't have the same length.
+		return s1.length === s2.length && timingSafeEqual(new Buffer(s1), new Buffer(s2));
 	}
 }
 


### PR DESCRIPTION
This [function](https://nodejs.org/api/crypto.html#crypto_crypto_timingsafeequal_a_b) is back in core node.js, so we don't need to use an external library any more.

Just to be sure, tested with the expected header, a header with the wrong length, and a header with the right length but wrong content.