### PR TITLE
Add retry logic to npmjs.org reads

### DIFF
--- a/src/lib/search-index-generator.ts
+++ b/src/lib/search-index-generator.ts
@@ -37,7 +37,7 @@ export async function createSearchRecord(info: AnyPackage, skipDownloads: boolea
 		} else {
 			const url = `https://api.npmjs.org/downloads/point/last-month/${info.typingsPackageName}`;
 			interface NpmResult { downloads: number; }
-			const json = <NpmResult> (await fetchJson(url));
+			const json = <NpmResult> (await fetchJson(url, { retries: true }));
 			// Json may contain "error" instead of "downloads", because some packages aren't available on NPM.
 			return json.downloads || 0;
 		}

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -74,7 +74,7 @@ export default class Versions {
 async function fetchVersionInfoFromNpm(packageName: string): Promise<VersionInfo> {
 	const escapedPackageName = fullPackageName(packageName).replace(/\//g, "%2f");
 	const uri = settings.npmRegistry + escapedPackageName;
-	const info = await fetchJson(uri);
+	const info = await fetchJson(uri, { retries: true });
 
 	if (info.error) {
 		if (info.error === "Not found") {


### PR DESCRIPTION
We are still getting occasional errors from `npmjs.org` accesses. (The next publish usually succeeds so this only results in a delay in publishing.) #144 isn't enough. This adds logic to retry a default of 5 times before throwing an error.