### PR TITLE
Store versions as { major, minor, patch } semver objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,12 +376,6 @@ This is the path to the DefinitelyTyped (or other similarly-structured) repo.
 
 This is the URL of the DefinitelyTyped repo.
 
-### prereleaseTag
-
-Optional. Example value `alpha`
-
-If present, packages are published with an e.g. `-alpha` prerelease tag as part of the version.
-
 ### tag
 
 Optional. Example value `latest`

--- a/settings.json
+++ b/settings.json
@@ -6,7 +6,6 @@
 	"definitelyTypedPath": "../DefinitelyTyped",
 	"sourceRepository": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
 	"sourceBranch": "types-2.0",
-	"prereleaseTag": null,
 	"tag": "latest",
 
 	"azureStorageAccount": "typespublisher",

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -78,9 +78,9 @@ export interface TypingsData extends PackageCommonProperties {
 	authors: string;
 
 	// The major version of the library (e.g. "1" for 1.0, "2" for 2.0)
-	libraryMajorVersion: string;
+	libraryMajorVersion: number;
 	// The minor version of the library
-	libraryMinorVersion: string;
+	libraryMinorVersion: number;
 
 	// The full path to the containing folder of all files, e.g. "C:/github/DefinitelyTyped/some-package"
 	root: string;

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 
 import { readdirRecursive, readFile as readFileText } from "../util/io";
 import { Logger, LoggerWithErrors, LogWithErrors, quietLoggerWithErrors } from "../util/logging";
-import { mapAsyncOrdered, normalizeSlashes, stripQuotes } from "../util/util";
+import { mapAsyncOrdered, normalizeSlashes, intOfString, stripQuotes } from "../util/util";
 
 import { RejectionReason, TypingsData, computeHash, definitelyTypedPath, settings } from "./common";
 
@@ -85,8 +85,8 @@ function getNamespaceFlags(ns: ts.ModuleDeclaration): DeclarationFlags {
 
 interface Metadata {
 	authors: string;
-	libraryMajorVersion: string;
-	libraryMinorVersion: string;
+	libraryMajorVersion: number;
+	libraryMinorVersion: number;
 	libraryName: string;
 	projectName: string;
 }
@@ -98,8 +98,8 @@ function parseMetadata(mainFileContent: string): Metadata {
 	}
 
 	const authors = regexMatch(/^\/\/ Definitions by: (.+)$/m, "Unknown");
-	const libraryMajorVersion = regexMatch(/^\/\/ Type definitions for [^\n]+ v?(\d+)/m, "0");
-	const libraryMinorVersion = regexMatch(/^\/\/ Type definitions for [^\n]+ v?\d+\.(\d+)/m, "0");
+	const libraryMajorVersion = intOfString(regexMatch(/^\/\/ Type definitions for [^\n]+ v?(\d+)/m, "0"));
+	const libraryMinorVersion = intOfString(regexMatch(/^\/\/ Type definitions for [^\n]+ v?\d+\.(\d+)/m, "0"));
 	const libraryName = regexMatch(/^\/\/ Type definitions for (.+)$/m, "Unknown").trim();
 	const projectName = regexMatch(/^\/\/ Project: (.+)$/m, "");
 

--- a/src/settings.d.ts
+++ b/src/settings.d.ts
@@ -19,9 +19,6 @@ interface PublishSettings {
 	// The branch that DefinitelyTyped is sourced from
 	sourceBranch: string;
 
-	// e.g. 'alpha'
-	prereleaseTag?: string;
-
 	// e.g. 'latest'
 	tag?: string;
 

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -76,3 +76,19 @@ export function normalizeSlashes(path: string): string {
 export function hasOwnProperty(object: {}, propertyName: string): boolean {
 	return Object.prototype.hasOwnProperty.call(object, propertyName);
 }
+
+export function intOfString(str: string) {
+	const n = Number.parseInt(str, 10);
+	if (Number.isNaN(n)) {
+		throw new Error(`Error in parseInt(${JSON.stringify(str)})`);
+	}
+	return n;
+}
+
+export function sortObjectKeys<T extends { [key: string]: any }>(data: T): T {
+	const out = {} as T;
+	for (const key of Object.keys(data).sort()) {
+		out[key] = data[key];
+	}
+	return out;
+}


### PR DESCRIPTION
This fixes an error where we would publish "0.0.1", "0.0.2", "0.1.3".
Now we will publish "0.0.0", "0.0.1", "0.1.0".

Also get rid of `settings.prereleaseTag` since we don't do that any more and it hasn't been supported for a while (as it would break version parsing).