### PR TITLE
Allow a package name to start with an underscore (publish `_debugger`)

### DIFF
--- a/src/parse-definitions.ts
+++ b/src/parse-definitions.ts
@@ -33,7 +33,7 @@ async function processDir(name: string): Promise<{ data: TypingsData | undefined
 async function filterPaths(paths: string[]): Promise<string[]> {
 	const fullPaths = paths
 		// Remove hidden paths and known non-package directories
-		.filter(s => s[0] !== "_" && s[0] !== "." && s !== "node_modules" && s !== "scripts")
+		.filter(s => s[0] !== "." && s !== "node_modules" && s !== "scripts")
 		// Sort by name
 		.sort();
 	// Remove non-folders


### PR DESCRIPTION
Re: DefinitelyTyped/DefinitelyTyped#12585