### PR TITLE
Undo #184: disallow underscore

### DIFF
--- a/src/parse-definitions.ts
+++ b/src/parse-definitions.ts
@@ -33,7 +33,7 @@ async function processDir(name: string, options: Options): Promise<{ data: Typin
 async function filterPaths(paths: string[], options: Options): Promise<string[]> {
 	const fullPaths = paths
 		// Remove hidden paths and known non-package directories
-		.filter(s => s[0] !== "." && s !== "node_modules" && s !== "scripts")
+		.filter(s => s[0] !== "." && s !== "_" && s !== "node_modules" && s !== "scripts")
 		// Sort by name
 		.sort();
 	// Remove non-folders


### PR DESCRIPTION
Npm won't let us publish `@types/_debugger`. We'll have to rename that.