### PR TITLE
Use typescript@next

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "source-map-support": "^0.4.0",
     "tar": "^2.2.1",
     "tslint": "4.0.0-dev.1",
-    "typescript": "^2.0.8",
+    "typescript": "next",
     "yargs": "^6.2.0"
   },
   "devDependencies": {

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -380,7 +380,7 @@ async function getModuleInfo(directory: string, folderName: string, allEntryFile
 					break;
 
 				case ts.SyntaxKind.ModuleDeclaration:
-					if (node.flags & ts.NodeFlags.Export) {
+					if (isExport(node)) {
 						log(`Found exported namespace \`${(node as ts.ModuleDeclaration).name.getText()}\``);
 						isProperModule = true;
 					} else {
@@ -400,7 +400,7 @@ async function getModuleInfo(directory: string, folderName: string, allEntryFile
 					break;
 
 				case ts.SyntaxKind.VariableStatement:
-					if (node.flags & ts.NodeFlags.Export) {
+					if (isExport(node)) {
 						log("Found exported variables");
 						isProperModule = true;
 					} else {
@@ -419,7 +419,7 @@ async function getModuleInfo(directory: string, folderName: string, allEntryFile
 				case ts.SyntaxKind.ClassDeclaration:
 				case ts.SyntaxKind.FunctionDeclaration:
 					// If these nodes have an 'export' modifier, the file is an external module
-					if (node.flags & ts.NodeFlags.Export) {
+					if (isExport(node)) {
 						const declName = (node as ts.DeclarationStatement).name;
 						if (declName) {
 							log(`Found exported declaration "${declName.getText()}"`);
@@ -553,4 +553,8 @@ async function readFile(directory: string, fileName: string): Promise<string> {
 	const result = await readFileText(path.join(directory, fileName));
 	// Skip BOM
 	return (result.charCodeAt(0) === 0xFEFF) ? result.substr(1) : result;
+}
+
+function isExport(node: ts.Node): boolean {
+	return (ts as any).hasModifier(node, ts.ModifierFlags.Export);
 }

--- a/src/tslint/noParentReferencesRule.ts
+++ b/src/tslint/noParentReferencesRule.ts
@@ -10,7 +10,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 		type: "functionality"
 	};
 
-	static FAILURE_STRING = "Don't use <reference path> to reference another package. Use an import or <reference types> instead."
+	static FAILURE_STRING = "Don't use <reference path> to reference another package. Use an import or <reference types> instead.";
 
 	apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
 		return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));


### PR DESCRIPTION
This means that any regressions in the TypeScript compiler will start getting picked up by DefinitelyTyped testing.
A side effect is that DefinitelyTyped packages might start using 2.1-specific features; though we don't want to encourage this.