### PR TITLE
Write new header parser with strict mode for linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "npm-registry-client": "^7.1.2",
     "object.entries": "^1.0.3",
     "object.values": "^1.0.3",
+    "parsimmon": "^1.0.0",
     "recursive-readdir": "^2.0.0",
     "source-map-support": "^0.4.0",
     "tar": "^2.2.1",
@@ -27,6 +28,7 @@
   "devDependencies": {
     "@types/node": "^6.0.41",
     "@types/node-fetch": "1.6.5",
+    "@types/parsimmon": "^0.9.31",
     "@types/recursive-readdir": "^1.2.27",
     "@types/source-map-support": "^0.2.27",
     "@types/tar": "^1.0.27",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "recursive-readdir": "^2.0.0",
     "source-map-support": "^0.4.0",
     "tar": "^2.2.1",
-    "tslint": "4.0.0-dev.1",
+    "tslint": "next",
     "typescript": "next",
     "yargs": "^6.2.0"
   },

--- a/src/lib/header.ts
+++ b/src/lib/header.ts
@@ -1,0 +1,193 @@
+import { intOfString, skipBOM } from "../util/util";
+import pm = require("parsimmon");
+
+/*
+Example:
+// Type definitions for foo 1.2
+// Project: https://github.com/foo/foo, https://foo.com
+// Definitions by: My Self <https://github.com/me>, Some Other Guy <https://github.com/otherguy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+*/
+
+export interface Header {
+	libraryName: string;
+	libraryMajorVersion: number;
+	libraryMinorVersion: number;
+	projects: string[];
+	authors: Author[];
+}
+
+export interface Author { name: string; url: string; }
+
+interface ParseError {
+	index: number;
+	line: number;
+	column: number;
+	expected: string[];
+}
+
+export function parseHeaderOrFail(mainFileContent: string, name: string): Header {
+	const header = parseHeader(mainFileContent, /*strict*/false);
+	if (isParseError(header)) {
+		throw new Error(`In ${name}: ${renderParseError(header)}`);
+	}
+	return header as Header;
+}
+
+export function validate(mainFileContent: string): ParseError | undefined {
+	const h = parseHeader(mainFileContent, /*strict*/true);
+	return isParseError(h) ? h : undefined;
+}
+
+export function renderExpected(expected: string[]): string {
+	return expected.length === 1 ? expected[0] : `one of\n\t${expected.join("\n\t")}`;
+}
+
+function renderParseError({ line, column, expected }: ParseError): string {
+	return `At ${line}:${column} : Expected ${renderExpected(expected)}`;
+}
+
+function isParseError(x: {}): x is ParseError {
+	return !!(x as ParseError).expected;
+}
+
+/** @param strict If true, we allow fewer things to be parsed. Turned on by linting. */
+function parseHeader(text: string, strict: boolean): Header | ParseError {
+	text = skipBOM(text);
+	const res = headerParser(strict).parse(text);
+
+	if (res.status) {
+		const { label: { name, major, minor }, projects, authors } = res.value!;
+		return { libraryName: name, libraryMajorVersion: major, libraryMinorVersion: minor, projects, authors };
+	}
+	// parsimmon types are wrong: expected is actually string[]
+	return { index: res.index!.offset, line: res.index!.line, column: res.index!.column, expected: res.expected as any as string[] };
+}
+
+function headerParser(strict: boolean): pm.Parser<{ label: Label, projects: string[], authors: Author[] }> {
+	return pm.seqMap(
+		pm.string("// Type definitions for "),
+		parseLabel(strict),
+		pm.string("// Project: "),
+		projectParser,
+		pm.regexp(/\r?\n\/\/ Definitions by: /),
+		authorsParser(strict),
+		parseDefinitions,
+		pm.all, // Don't care about the rest of the file
+		// tslint:disable-next-line:variable-name
+		(_str, label, _project, projects, _defsBy, authors) => ({ label, projects, authors }));
+}
+
+interface Label { name: string; major: number; minor: number; }
+
+/*
+Allow any of the following:
+
+// Project: https://foo.com
+//          https://bar.com
+
+// Project: https://foo.com,
+//          https://bar.com
+
+// Project: https://foo.com, https://bar.com
+
+Use `\s\s+` to ensure at least 2 spaces, to  disambiguate from the next line being `// Definitions by:`.
+*/
+const separator: pm.Parser<string> = pm.regexp(/(, )|(,?\r?\n\/\/\s\s+)/);
+
+const projectParser: pm.Parser<string[]> = pm.sepBy1(pm.regexp(/[^,\r\n]+/), separator);
+
+function authorsParser(strict: boolean): pm.Parser<Author[]> {
+	const author = pm.seqMap(pm.regexp(/([^<]+) /, 1), pm.regexp(/<([^>]+)>/, 1), (name, url) => ({ name, url }));
+	const authors = pm.sepBy1(author, separator);
+	if (!strict) {
+		// Allow trailing whitespace.
+		return pm.seqMap(authors, pm.regexp(/ */), a => a);
+	}
+	return authors;
+};
+
+// TODO: Should we do something with the URL?
+const parseDefinitions = pm.regexp(/\r?\n\/\/ Definitions: [^\r\n]+/);
+
+function parseLabel(strict: boolean): pm.Parser<Label> {
+	return pm.Parser((input, index) => {
+		// Take all until the first newline.
+		const endIndex = regexpIndexOf(input, /\r|\n/, index);
+		if (endIndex === -1) {
+			return fail("EOF");
+		}
+		// Index past the end of the newline.
+		const end = input[endIndex] === "\r" ? endIndex + 2 : endIndex + 1;
+		const tilNewline = input.slice(index, endIndex);
+
+		// Parse in reverse. Once we've stripped off the version, the rest is the libary name.
+		const reversed = reverse(tilNewline);
+
+		const rgx = /((\d+)\.(\d+)(\.\d+)?(v)? )?(.+)/;
+		const match = rgx.exec(reversed);
+		if (!match) {
+			return fail();
+		}
+		const [, version, a, b, c, v, nameReverse] = match;
+
+		let majorReverse: string, minorReverse: string;
+		if (version) {
+			if (c) {
+				// There is a patch version
+				majorReverse = c;
+				minorReverse = b;
+				if (strict) {
+					return fail("patch version not allowed");
+				}
+			} else {
+				majorReverse = b;
+				minorReverse = a;
+			}
+			if (v && strict) {
+				return fail("'v' not allowed");
+			}
+		}
+		else {
+			if (strict) {
+				return fail("Needs MAJOR.MINOR");
+			}
+			majorReverse = "0"; minorReverse = "0";
+		}
+
+		const [name, major, minor] = [reverse(nameReverse), reverse(majorReverse), reverse(minorReverse)];
+		return pm.makeSuccess<Label>(end, { name, major: intOfString(major), minor: intOfString(minor) });
+
+		function fail(msg?: string): pm.Result<Label> {
+			let expected = "foo MAJOR.MINOR";
+			if (msg) {
+				expected += ` (${msg})`;
+			}
+			return pm.makeFailure(index, expected);
+		}
+	});
+}
+
+function reverse(s: string): string {
+	let out = "";
+	for (let i = s.length - 1; i >= 0; i--) {
+		out += s[i];
+	}
+	return out;
+}
+
+function regexpIndexOf(s: string, rgx: RegExp, start: number): number {
+	const index = s.slice(start).search(rgx);
+	return index === -1 ? index : index + start;
+}
+
+declare module "parsimmon" {
+	export function Parser<T>(fn: (input: string, index: number) => pm.Result<T>): pm.Parser<T>;
+	export function makeSuccess<T>(endIndex: number, result: T): pm.Result<T>;
+	export function makeFailure(index: number, expected: string): pm.Result<any>;
+
+	export function sepBy1<T>(a: pm.Parser<T>, b: pm.Parser<any>): Parser<T[]>;
+	export function seqMap<T, U, V, W, X, Y, Z, AA, BB>(
+		p1: Parser<T>, p2: Parser<U>, p3: Parser<V>, p4: Parser<W>, p5: Parser<X>, p6: Parser<Y>, p7: Parser<Z>, p8: Parser<AA>,
+		cb: (a1: T, a2: U, a3: V, a4: W, a5: X, a6: Y, a7: Z, a8: AA) => BB): Parser<BB>;
+}

--- a/src/tslint/dtHeaderRule.ts
+++ b/src/tslint/dtHeaderRule.ts
@@ -1,0 +1,39 @@
+import * as Lint from "tslint";
+import * as ts from "typescript";
+
+import { validate, renderExpected } from "../lib/header";
+
+export class Rule extends Lint.Rules.AbstractRule {
+	static metadata: Lint.IRuleMetadata = {
+		ruleName: "dt-header",
+		description: "Ensure consistency of DefinitelyTyped headers.",
+		rationale: "Consistency is a good.",
+		optionsDescription: "Not configurable.",
+		options: null,
+		type: "functionality",
+		typescriptOnly: true,
+	};
+
+	apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+		return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
+	}
+}
+
+class Walker extends Lint.RuleWalker {
+	visitSourceFile(node: ts.SourceFile) {
+		const text = node.getFullText();
+
+		if (!node.fileName.endsWith("index.d.ts")) {
+			if (text.startsWith("// Type definitions for")) {
+				this.addFailure(this.createFailure(0, 1, "Header should only be in `index.d.ts`."));
+			}
+			return;
+		}
+
+		const error = validate(text);
+		if (error) {
+			this.addFailure(this.createFailure(error.index, error.index + 1, `Error parsing header. Expected: ${renderExpected(error.expected)}`));
+		}
+		// Don't recurse, we're done.
+	}
+}

--- a/src/tslint/forbiddenTypesRule.ts
+++ b/src/tslint/forbiddenTypesRule.ts
@@ -1,4 +1,4 @@
-import * as Lint from "tslint/lib/lint";
+import * as Lint from "tslint";
 import * as ts from "typescript";
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -6,8 +6,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 		ruleName: "forbidden-types",
 		description: "Forbid the Function, Object, Boolean, Number, and String types.",
 		rationale: "Certain types are never a good idea.",
-		options: {},
-		type: "functionality"
+		optionsDescription: "Not configurable.",
+		options: null,
+		type: "functionality",
+		typescriptOnly: true,
 	};
 
 	static upperCaseFailureString(name: string) {

--- a/src/tslint/functionalInterfacesRule.ts
+++ b/src/tslint/functionalInterfacesRule.ts
@@ -1,4 +1,4 @@
-import * as Lint from "tslint/lib/lint";
+import * as Lint from "tslint";
 import * as ts from "typescript";
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -6,8 +6,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 		ruleName: "functional-interface",
 		description: "An interface with just a call signature can be written as a function type.",
 		rationale: "For simplicity",
-		options: {},
-		type: "style"
+		optionsDescription: "Not configurable.",
+		options: null,
+		type: "style",
+		typescriptOnly: true,
 	};
 
 	static failureString(name: string, { parameters, returnType }: Signature): string {

--- a/src/tslint/interfaceOverTypeLiteralRule.ts
+++ b/src/tslint/interfaceOverTypeLiteralRule.ts
@@ -1,4 +1,4 @@
-import * as Lint from "tslint/lib/lint";
+import * as Lint from "tslint";
 import * as ts from "typescript";
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -6,8 +6,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 		ruleName: "interface-over-type-literal",
 		description: "Prefer an interface declaration over `type T = { ... }`",
 		rationale: "For consistency",
-		options: {},
-		type: "style"
+		optionsDescription: "Not configurable.",
+		options: null,
+		type: "style",
+		typescriptOnly: true,
 	};
 
 	static FAILURE_STRING = "Use an interface instead.";

--- a/src/tslint/noEmptyInterfaceRule.ts
+++ b/src/tslint/noEmptyInterfaceRule.ts
@@ -1,4 +1,4 @@
-import * as Lint from "tslint/lib/lint";
+import * as Lint from "tslint";
 import * as ts from "typescript";
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -6,8 +6,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 		ruleName: "no-empty-interface",
 		description: "Forbids empty interfaces",
 		rationale: "Empty interfaces as not useful.",
-		options: {},
-		type: "style"
+		optionsDescription: "Not configurable.",
+		options: null,
+		type: "style",
+		typescriptOnly: true,
 	};
 
 	static FAILURE_STRING = "An empty interface is equivalent to `{}`.";

--- a/src/tslint/noParentReferencesRule.ts
+++ b/src/tslint/noParentReferencesRule.ts
@@ -1,4 +1,4 @@
-import * as Lint from "tslint/lib/lint";
+import * as Lint from "tslint";
 import * as ts from "typescript";
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -6,8 +6,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 		ruleName: "no-parent-references",
 		description: 'Forbid <reference path="../etc"/>',
 		rationale: "Parent references are not inferred as dependencies by types-publisher.",
-		options: {},
-		type: "functionality"
+		optionsDescription: "Not configurable.",
+		options: null,
+		type: "functionality",
+		typescriptOnly: true,
 	};
 
 	static FAILURE_STRING = "Don't use <reference path> to reference another package. Use an import or <reference types> instead.";

--- a/src/tslint/noPublicRule.ts
+++ b/src/tslint/noPublicRule.ts
@@ -1,4 +1,4 @@
-import * as Lint from "tslint/lib/lint";
+import * as Lint from "tslint";
 import * as ts from "typescript";
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -6,8 +6,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 		ruleName: "no-public",
 		description: "Forbids the 'public' keyword.",
 		rationale: "For simplicity",
-		options: {},
-		type: "style"
+		optionsDescription: "Not configurable.",
+		options: null,
+		type: "style",
+		typescriptOnly: true,
 	};
 
 	static FAILURE_STRING = "No need to write `public`; this is implicit.";

--- a/src/tslint/noSingleDeclareModuleRule.ts
+++ b/src/tslint/noSingleDeclareModuleRule.ts
@@ -1,4 +1,4 @@
-import * as Lint from "tslint/lib/lint";
+import * as Lint from "tslint";
 import * as ts from "typescript";
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -6,8 +6,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 		ruleName: "no-single-declare-module",
 		description: "Don't use an ambient module declaration if you can use an external module file.",
 		rationale: "Cuts down on nesting",
-		options: {},
-		type: "style"
+		optionsDescription: "Not configurable.",
+		options: null,
+		type: "style",
+		typescriptOnly: true,
 	};
 
 	static FAILURE_STRING = "File has only 1 module declaration — write it as an external module.";

--- a/src/tslint/unifiedSignaturesRule.ts
+++ b/src/tslint/unifiedSignaturesRule.ts
@@ -1,4 +1,4 @@
-import * as Lint from "tslint/lib/lint";
+import * as Lint from "tslint";
 import * as ts from "typescript";
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -6,8 +6,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 		ruleName: "array-type-style",
 		description: "Array types should be written with the `Foo[]` syntax",
 		rationale: "For consistency",
-		options: {},
-		type: "style"
+		optionsDescription: "Not configurable.",
+		options: null,
+		type: "style",
+		typescriptOnly: true,
 	};
 
 	static FAILURE_STRING_OMITTING_SINGLE_PARAMETER = `These overloads can be combined into one signature with an optional parameter.`;

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -123,3 +123,7 @@ export async function execAndThrowErrors(cmd: string, cwd?: string): Promise<str
 	}
 	return stdout;
 }
+
+export function skipBOM(str: string): string {
+	return str.charCodeAt(0) === 0xFEFF ? str.slice(1) : str;
+}

--- a/tslint-common.json
+++ b/tslint-common.json
@@ -5,6 +5,7 @@
 	],
 	"rules": {
 		// Custom rules
+		"dt-header": true,
 		"forbidden-types": true,
 		"functional-interfaces": true,
 		"interface-over-type-literal": true,
@@ -24,6 +25,7 @@
 		"no-console": false,
 		"no-namespace": false,
 		"object-literal-sort-keys": false,
+		"one-variable-per-declaration": false,
 		"ordered-imports": false,
 		"prefer-for-of": false, // Enable when https://github.com/palantir/tslint/pull/1758 is in
 		"trailing-comma": false

--- a/tslint-common.json
+++ b/tslint-common.json
@@ -15,7 +15,9 @@
 		"unified-signatures": true,
 
 		"array-type": [true, "array-simple"],
+		"arrow-parens": false,
 		"interface-name": false,
+		"max-classes-per-file": false,
 		"member-access": false,
 		"member-ordering": false,
 		"no-bitwise": false,
@@ -23,6 +25,7 @@
 		"no-namespace": false,
 		"object-literal-sort-keys": false,
 		"ordered-imports": false,
+		"prefer-for-of": false, // Enable when https://github.com/palantir/tslint/pull/1758 is in
 		"trailing-comma": false
     }
 }


### PR DESCRIPTION
We will now lint the header by default.
Related: DefinitelyTyped/DefinitelyTyped#12829, DefinitelyTyped/DefinitelyTyped#12833
Inspired by https://github.com/DefinitelyTyped/definition-header