### PR TITLE
Remove 'scripts' kludge and lint

### DIFF
--- a/src/lib/package-generator.ts
+++ b/src/lib/package-generator.ts
@@ -5,7 +5,8 @@ import { readFile, readJson, writeFile } from "../util/io";
 import { Log, Logger, quietLogger } from "../util/logging";
 import { hasOwnProperty } from "../util/util";
 
-import { AnyPackage, Options, TypesDataFile, TypingsData, NotNeededPackage, filePath, fullPackageName, notNeededReadme, getOutputPath } from "./common";
+import { AnyPackage, Options, TypesDataFile, TypingsData, NotNeededPackage, filePath, fullPackageName, notNeededReadme, getOutputPath
+	} from "./common";
 import Versions, { Semver, VersionInfo, versionString } from "./versions";
 
 /** Generates the package to disk */
@@ -99,7 +100,8 @@ interface PartialPackageJson {
 	description?: string;
 }
 
-async function createPackageJSON(typing: TypingsData, { version, contentHash }: VersionInfo, availableTypes: TypesDataFile, options: Options): Promise<string> {
+async function createPackageJSON(typing: TypingsData, { version, contentHash }: VersionInfo, availableTypes: TypesDataFile, options: Options
+	): Promise<string> {
 	// typing may provide a partial `package.json` for us to complete
 	const pkgPath = filePath(typing, "package.json", options);
 	let pkg: PartialPackageJson = typing.hasPackageJson ? await readJson(pkgPath) : {};

--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -97,7 +97,6 @@ async function single(pkg: TypingsData, log: LoggerWithErrors, options: Options)
 	return (await tsConfig()) || (await packageJson()) || (await tsc()) || (await tslint());
 
 	async function tsConfig(): Promise<TesterError | undefined> {
-		//use filePath
 		const tsconfigPath = path.join(cwd, "tsconfig.json");
 		return catchErrors(log, async () =>
 			checkTsconfig(await readJson(tsconfigPath)));
@@ -174,8 +173,7 @@ async function checkPackageJson(typing: TypingsData, options: Options): Promise<
 	const pkg = await readJson(pkgPath);
 
 	const ignoredField = Object.keys(pkg).find(field => !["dependencies", "peerDependencies", "description"].includes(field));
-	// Kludge: ignore "scripts" (See https://github.com/DefinitelyTyped/definition-tester/issues/35)
-	if (ignoredField && ignoredField !== "scripts") {
+	if (ignoredField) {
 		throw new Error(`Ignored field in ${pkgPath}: ${ignoredField}`);
 	}
 }


### PR DESCRIPTION
We no longer use `"scripts"` in `package.json` of any DefinitelyTyped package, so remove the kludge that allowed it.