### PR TITLE
Forbid "types" to be non-empty in tsconfig.json

### DIFF
--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -162,6 +162,9 @@ function checkTsconfig(tsconfig: any) {
 	}
 
 	// baseUrl / typeRoots / types may be missing.
+	if (options.types && options.types.length) {
+		throw new Error('Use `/// <reference types="" />` in source files instead of using "types" in tsconfig.');
+	}
 }
 
 async function checkPackageJson(typing: TypingsData, options: Options): Promise<void> {


### PR DESCRIPTION
We don't process this field, so published packages will be missing dependencies.