### PR TITLE
Add lint rule: Only allow `void` as return type

### DIFF
--- a/src/tslint/voidReturnRule.ts
+++ b/src/tslint/voidReturnRule.ts
@@ -1,0 +1,51 @@
+import * as Lint from "tslint";
+import * as ts from "typescript";
+
+export class Rule extends Lint.Rules.AbstractRule {
+	static metadata: Lint.IRuleMetadata = {
+		ruleName: "void-return",
+		description: "`void` may only be used as a return type.",
+		rationale: "style",
+		optionsDescription: "Not configurable.",
+		options: null,
+		type: "style",
+		typescriptOnly: true,
+	};
+
+	static FAILURE_STRING = "Use the `void` type for return types only. Otherwise, use `undefined`.";
+
+	apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+		return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
+	}
+}
+
+class Walker extends Lint.RuleWalker {
+    visitNode(node: ts.Node) {
+        if (node.kind === ts.SyntaxKind.VoidKeyword) {
+            //todo: isFunctionLike...
+            const parent = node.parent!;
+            if (!(isSignatureDeclaration(parent) && parent.type === node)) {
+                this.fail(node, Rule.FAILURE_STRING);
+            }
+        }
+        super.visitNode(node);
+    }
+
+    private fail(node: ts.Node, message: string) {
+		this.addFailure(this.createFailure(node.getStart(), node.getWidth(), message));
+	}
+}
+
+function isSignatureDeclaration(node: ts.Node): node is ts.SignatureDeclaration {
+    switch (node.kind) {
+        case ts.SyntaxKind.ArrowFunction:
+        case ts.SyntaxKind.FunctionDeclaration:
+        case ts.SyntaxKind.FunctionType:
+        case ts.SyntaxKind.MethodDeclaration:
+        case ts.SyntaxKind.MethodSignature:
+            return true;
+
+        default:
+            return false;
+    }
+}

--- a/src/tslint/voidReturnRule.ts
+++ b/src/tslint/voidReturnRule.ts
@@ -21,12 +21,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class Walker extends Lint.RuleWalker {
 	visitNode(node: ts.Node) {
-		if (node.kind === ts.SyntaxKind.VoidKeyword) {
-			//todo: isFunctionLike...
-			const parent = node.parent!;
-			if (!(isSignatureDeclaration(parent) && parent.type === node)) {
-				this.fail(node, Rule.FAILURE_STRING);
-			}
+		if (node.kind === ts.SyntaxKind.VoidKeyword && !isPromiseType(node) && !isReturnType(node)) {
+			this.fail(node, Rule.FAILURE_STRING);
 		}
 		super.visitNode(node);
 	}
@@ -34,6 +30,32 @@ class Walker extends Lint.RuleWalker {
 	private fail(node: ts.Node, message: string) {
 		this.addFailure(this.createFailure(node.getStart(), node.getWidth(), message));
 	}
+}
+
+function isPromiseType(node: ts.Node): boolean {
+	const parent = node.parent!;
+	switch (parent.kind) {
+		case ts.SyntaxKind.TypeReference: {
+			const ref = parent as ts.TypeReferenceNode;
+			return isPromiseIdentifier(ref.typeName) && ref.typeArguments![0] === node;
+		}
+		case ts.SyntaxKind.NewExpression: {
+			const ctr = parent as ts.NewExpression;
+			return isPromiseIdentifier(ctr.expression) && ctr.typeArguments![0] === node;
+		}
+		default:
+			return false;
+	}
+
+}
+
+function isPromiseIdentifier(node: ts.Node): boolean {
+	return node.kind === ts.SyntaxKind.Identifier && (node as ts.Identifier).text === "Promise";
+}
+
+function isReturnType(node: ts.Node): boolean {
+	const parent = node.parent!;
+	return isSignatureDeclaration(parent) && parent.type === node;
 }
 
 function isSignatureDeclaration(node: ts.Node): node is ts.SignatureDeclaration {

--- a/src/tslint/voidReturnRule.ts
+++ b/src/tslint/voidReturnRule.ts
@@ -20,32 +20,32 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class Walker extends Lint.RuleWalker {
-    visitNode(node: ts.Node) {
-        if (node.kind === ts.SyntaxKind.VoidKeyword) {
-            //todo: isFunctionLike...
-            const parent = node.parent!;
-            if (!(isSignatureDeclaration(parent) && parent.type === node)) {
-                this.fail(node, Rule.FAILURE_STRING);
-            }
-        }
-        super.visitNode(node);
-    }
+	visitNode(node: ts.Node) {
+		if (node.kind === ts.SyntaxKind.VoidKeyword) {
+			//todo: isFunctionLike...
+			const parent = node.parent!;
+			if (!(isSignatureDeclaration(parent) && parent.type === node)) {
+				this.fail(node, Rule.FAILURE_STRING);
+			}
+		}
+		super.visitNode(node);
+	}
 
-    private fail(node: ts.Node, message: string) {
+	private fail(node: ts.Node, message: string) {
 		this.addFailure(this.createFailure(node.getStart(), node.getWidth(), message));
 	}
 }
 
 function isSignatureDeclaration(node: ts.Node): node is ts.SignatureDeclaration {
-    switch (node.kind) {
-        case ts.SyntaxKind.ArrowFunction:
-        case ts.SyntaxKind.FunctionDeclaration:
-        case ts.SyntaxKind.FunctionType:
-        case ts.SyntaxKind.MethodDeclaration:
-        case ts.SyntaxKind.MethodSignature:
-            return true;
+	switch (node.kind) {
+		case ts.SyntaxKind.ArrowFunction:
+		case ts.SyntaxKind.FunctionDeclaration:
+		case ts.SyntaxKind.FunctionType:
+		case ts.SyntaxKind.MethodDeclaration:
+		case ts.SyntaxKind.MethodSignature:
+			return true;
 
-        default:
-            return false;
-    }
+		default:
+			return false;
+	}
 }

--- a/tslint-common.json
+++ b/tslint-common.json
@@ -14,6 +14,7 @@
 		"no-public": true,
 		"no-single-declare-module": true,
 		"unified-signatures": true,
+		"void-return": true,
 
 		"array-type": [true, "array-simple"],
 		"arrow-parens": false,


### PR DESCRIPTION
Would this be a good rule? Spotted a stray `void` at DefinitelyTyped/DefinitelyTyped#13191.