### PR TITLE
Fix TypeScript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "source-map-support": "^0.4.0",
     "tar": "^2.2.1",
     "tslint": "next",
-    "typescript": "next",
+    "typescript": "^2.0.10",
     "yargs": "^6.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #210.
This undoes #192.
We discussed when to allow features from later TS versions on DefinitelyTyped, and the simplest way was to keep the TypeScript version on types-publisher fixed. A month after a new TypeScript version is released, we'll update the version. On Jan 7 we'll upgrade this to 2.1.