### PR TITLE
Add check for packages that provide their own typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "object.entries": "^1.0.3",
     "object.values": "^1.0.3",
     "parsimmon": "^1.0.0",
+    "semver": "^5.3.0",
     "source-map-support": "^0.4.0",
     "tar": "^2.2.1",
     "tslint": "next",
@@ -28,6 +29,7 @@
     "@types/node": "^6.0.41",
     "@types/node-fetch": "1.6.5",
     "@types/parsimmon": "^0.9.31",
+    "@types/semver": "^5.3.30",
     "@types/source-map-support": "^0.2.27",
     "@types/tar": "^1.0.27",
     "@types/yargs": "^6.3.1"

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -128,3 +128,18 @@ export async function execAndThrowErrors(cmd: string, cwd?: string): Promise<str
 export function errorDetails(error: Error): string {
 	return error.stack || error.message || `Non-Error error: ${inspect(error)}`;
 }
+
+export function min<T>(inputs: T[], lessThan: (a: T, b: T) => boolean): T | undefined {
+	if (!inputs.length) {
+		return undefined;
+	}
+
+	let min = inputs[0];
+	for (let i = 1; i < inputs.length; i++) {
+		const candidate = inputs[i];
+		if (lessThan(candidate, min)) {
+			min = candidate;
+		}
+	}
+	return min;
+}

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
 		"indent": [true, "tabs"],
 		"max-line-length": [true, 150],
 		"no-var-requires": false,
-		"one-line": false
+		"one-line": false,
+		"variable-name": false
 	}
 }


### PR DESCRIPTION
This produces a long list. Even after we've fixed those, we should leave this as a warning because we don't know when a package will add typings.