### PR TITLE
Look for previously-published package versions with the same major/minor version when detecting "old" version.

### DIFF
--- a/src/check-parse-results.ts
+++ b/src/check-parse-results.ts
@@ -2,7 +2,7 @@ import * as semver from "semver";
 import { TypingsData, existsTypesDataFileSync, readTypings, settings } from "./lib/common";
 import { Logger, logger, writeLog } from "./util/logging";
 import { fetchJson} from "./util/io";
-import { done, min, nAtATime } from "./util/util";
+import { best, done, nAtATime } from "./util/util";
 
 if (!module.parent) {
 	if (!existsTypesDataFileSync()) {
@@ -54,7 +54,7 @@ async function checkNpm(pkg: TypingsData, log: Logger): Promise<void> {
 
 function firstVersionWithTypes(versions: { [version: string]: any }): string | undefined {
 	const versionsWithTypings = Object.entries(versions).filter(([_version, info]) => hasTypes(info)).map(([version]) => version);
-	return min(versionsWithTypings, semver.lt);
+	return best(versionsWithTypings, semver.lt);
 }
 
 function hasTypes(info: any): boolean {

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -3,7 +3,7 @@ import assert = require("assert");
 import { existsDataFileSync, readDataFile, writeDataFile } from "../lib/common";
 import { fetchJson } from "../util/io";
 import { Logger } from "../util/logging";
-import { max, nAtATime, intOfString, sortObjectKeys } from "../util/util";
+import { best, nAtATime, intOfString, sortObjectKeys } from "../util/util";
 
 import { AnyPackage, AllPackages, fullPackageName, settings } from "./common";
 
@@ -153,7 +153,7 @@ function latestPatchMatchingMajorAndMinor(versions: { [version: string]: never }
 		const { major, minor, patch } = semver;
 		return major === newMajor && minor === newMinor ? patch : undefined;
 	}).filter(x => x !== undefined);
-	return max(versionsWithTypings, (a, b) => a > b);
+	return best(versionsWithTypings, (a, b) => a > b);
 }
 
 function parseSemver(semver: string): Semver {

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -3,7 +3,7 @@ import assert = require("assert");
 import { existsDataFileSync, readDataFile, writeDataFile } from "../lib/common";
 import { fetchJson } from "../util/io";
 import { Logger } from "../util/logging";
-import { nAtATime, intOfString, sortObjectKeys } from "../util/util";
+import { max, nAtATime, intOfString, sortObjectKeys } from "../util/util";
 
 import { AnyPackage, AllPackages, fullPackageName, settings } from "./common";
 
@@ -34,7 +34,7 @@ export default class Versions {
 
 		await nAtATime(25, typings, async pkg => {
 			const packageName = pkg.typingsPackageName;
-			const versionInfo = await fetchTypesPackageVersionInfo(packageName);
+			const versionInfo = await fetchTypesPackageVersionInfo(packageName, [pkg.libraryMajorVersion, pkg.libraryMinorVersion]);
 			if (!versionInfo) {
 				log(`Added: ${packageName}`);
 				additions.push(packageName);
@@ -101,11 +101,11 @@ export function versionString(version: Semver): string {
 }
 
 /** Returns undefined if the package does not exist. */
-async function fetchTypesPackageVersionInfo(packageName: string): Promise<VersionInfo | undefined> {
-	return fetchVersionInfoFromNpm(fullPackageName(packageName).replace(/\//g, "%2f"));
+async function fetchTypesPackageVersionInfo(packageName: string, newMajorAndMinor?: [number, number]): Promise<VersionInfo | undefined> {
+	return fetchVersionInfoFromNpm(fullPackageName(packageName).replace(/\//g, "%2f"), newMajorAndMinor);
 }
 
-export async function fetchVersionInfoFromNpm(escapedPackageName: string): Promise<VersionInfo | undefined> {
+export async function fetchVersionInfoFromNpm(escapedPackageName: string, newMajorAndMinor?: [number, number]): Promise<VersionInfo | undefined> {
 	const uri = settings.npmRegistry + escapedPackageName;
 	const info = await fetchJson(uri, { retries: true });
 
@@ -122,8 +122,7 @@ export async function fetchVersionInfoFromNpm(escapedPackageName: string): Promi
 		return undefined;
 	}
 	else {
-		const versionSemver: string = info["dist-tags"].latest;
-		assert(typeof versionSemver === "string");
+		const versionSemver = getVersionSemver(info, newMajorAndMinor);
 		const latestVersionInfo = info.versions[versionSemver];
 		assert(!!latestVersionInfo);
 		const contentHash = latestVersionInfo.typesPublisherContentHash || "";
@@ -132,15 +131,45 @@ export async function fetchVersionInfoFromNpm(escapedPackageName: string): Promi
 	}
 }
 
+function getVersionSemver(info: any, newMajorAndMinor?: [number, number]): string {
+	// If there's already a published package with this version, look for that first.
+	if (newMajorAndMinor) {
+		const [newMajor, newMinor] = newMajorAndMinor;
+		const patch = newMajor === -1 ? undefined : latestPatchMatchingMajorAndMinor(info.versions, newMajor, newMinor);
+		if (patch !== undefined) {
+			return `${newMajor}.${newMinor}.${patch}`;
+		}
+	}
+	return info["dist-tags"].latest;
+}
+
+/** Finds the version with matching major/minor with the latest patch version. */
+function latestPatchMatchingMajorAndMinor(versions: { [version: string]: never }, newMajor: number, newMinor: number): number | undefined {
+	const versionsWithTypings = Object.keys(versions).map(v => {
+		const semver = tryParseSemver(v);
+		if (!semver) {
+			return undefined;
+		}
+		const { major, minor, patch } = semver;
+		return major === newMajor && minor === newMinor ? patch : undefined;
+	}).filter(x => x !== undefined);
+	return max(versionsWithTypings, (a, b) => a > b);
+}
+
 function parseSemver(semver: string): Semver {
+	const result = tryParseSemver(semver);
+	if (!result) {
+		throw new Error(`Unexpected semver: ${semver}`);
+	}
+	return result;
+}
+
+function tryParseSemver(semver: string): Semver | undefined {
 	// Per the semver spec <http://semver.org/#spec-item-2>:
  	// "A normal version number MUST take the form X.Y.Z where X, Y, and Z are non-negative integers, and MUST NOT contain leading zeroes."
 	const rgx = /^(\d+)\.(\d+)\.(\d+)$/;
 	const match = rgx.exec(semver);
-	if (!match) {
-		throw new Error(`Unexpected semver: ${semver}`);
-	}
-	return { major: intOfString(match[1]), minor: intOfString(match[2]), patch: intOfString(match[3]) };
+	return match ? { major: intOfString(match[1]), minor: intOfString(match[2]), patch: intOfString(match[3]) } : undefined;
 }
 
 // List of package names that have changed

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -143,3 +143,7 @@ export function min<T>(inputs: T[], lessThan: (a: T, b: T) => boolean): T | unde
 	}
 	return min;
 }
+export function max<T>(inputs: T[], greaterThan: (a: T, b: T) => boolean): T | undefined {
+	// Logic is the same either way.
+	return min(inputs, greaterThan);
+}

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -129,21 +129,21 @@ export function errorDetails(error: Error): string {
 	return error.stack || error.message || `Non-Error error: ${inspect(error)}`;
 }
 
-export function min<T>(inputs: T[], lessThan: (a: T, b: T) => boolean): T | undefined {
+/**
+ * Returns the input that is better than all others, or `undefined` if there are no inputs.
+ * @param isBetter Returns true if `a` should be preferred over `b`.
+ */
+export function best<T>(inputs: T[], isBetter: (a: T, b: T) => boolean): T | undefined {
 	if (!inputs.length) {
 		return undefined;
 	}
 
-	let min = inputs[0];
+	let best = inputs[0];
 	for (let i = 1; i < inputs.length; i++) {
 		const candidate = inputs[i];
-		if (lessThan(candidate, min)) {
-			min = candidate;
+		if (isBetter(candidate, best)) {
+			best = candidate;
 		}
 	}
-	return min;
-}
-export function max<T>(inputs: T[], greaterThan: (a: T, b: T) => boolean): T | undefined {
-	// Logic is the same either way.
-	return min(inputs, greaterThan);
+	return best;
 }


### PR DESCRIPTION
This means that if we publish node `6.0.51` and then node `0.0.0` due to bad version parsing, the next published will still be `6.0.52`.
Should do this before DefinitelyTyped/DefinitelyTyped#13239.