### PR TITLE
Allow packages to target typescript@next

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ data/
 logs/
 node_modules/
 output/
+typescript-installs
 validateOutput/

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "source-map-support": "^0.4.0",
     "tar": "^2.2.1",
     "tslint": "next",
-    "typescript": "^2.0.10",
+    "typescript": "next",
     "yargs": "^6.2.0"
   },
   "devDependencies": {

--- a/settings.json
+++ b/settings.json
@@ -5,7 +5,6 @@
 	"validateOutputPath": "./validateOutput",
 	"sourceRepository": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
 	"sourceBranch": "master",
-	"tag": "latest",
 
 	"azureStorageAccount": "typespublisher",
 	"azureContainer": "typespublisher",

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -41,7 +41,7 @@ export interface PackageCommonProperties {
 	// The name of the library (human readable, e.g. might be "Moment.js" even though packageName is "moment")
 	libraryName: string;
 
-	// The NPM name to publish this under, e.g. "jquery". May not be lower-cased yet.
+	// The NPM name to publish this under, e.g. "jquery". Does not include "@types".
 	typingsPackageName: string;
 
 	// e.g. https://github.com/DefinitelyTyped
@@ -70,6 +70,31 @@ export interface TypesDataFile {
 	[folderName: string]: TypingsData;
 }
 
+export type TypeScriptVersion = "2.0" | "2.1";
+export namespace TypeScriptVersion {
+	export const All: TypeScriptVersion[] = ["2.0", "2.1"];
+	export const Latest = "2.1";
+
+	export function isPrerelease(version: TypeScriptVersion): boolean {
+		return version === "2.1";
+	}
+
+	/** List of NPM tags that should be changed to point to the latest version. */
+	export function tagsToUpdate(typeScriptVersion: TypeScriptVersion): string[]  {
+		switch (typeScriptVersion) {
+			case "2.0":
+				// A 2.0-compatible package is assumed compatible with TypeScript 2.1
+				// We want the "2.1" tag to always exist.
+				return ["latest", "2.0", "2.1"];
+			case "2.1":
+				// Eventually this will change to include "latest", too.
+				// And obviously we shouldn't advance the "2.0" tag if the package is now 2.1-specific.
+				return ["2.1"];
+		}
+	}
+
+}
+
 export interface TypingsData extends PackageCommonProperties {
 	/**
 	 * Never include this property;
@@ -90,6 +115,8 @@ export interface TypingsData extends PackageCommonProperties {
 	libraryMajorVersion: number;
 	// The minor version of the library
 	libraryMinorVersion: number;
+
+	typeScriptVersion: TypeScriptVersion;
 
 	// Files that should be published with this definition, e.g. ["jquery.d.ts", "jquery-extras.d.ts"]
 	// Does *not* include a partial `package.json` because that will not be copied directly.

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -85,14 +85,19 @@ export namespace TypeScriptVersion {
 			case "2.0":
 				// A 2.0-compatible package is assumed compatible with TypeScript 2.1
 				// We want the "2.1" tag to always exist.
-				return ["latest", "2.0", "2.1"];
+				return [tags.latest, tags.v2_0, tags.v2_1];
 			case "2.1":
 				// Eventually this will change to include "latest", too.
 				// And obviously we shouldn't advance the "2.0" tag if the package is now 2.1-specific.
-				return ["2.1"];
+				return [tags.v2_1];
 		}
 	}
 
+	namespace tags {
+		export const latest = "latest";
+		export const v2_0 = "ts2.0";
+		export const v2_1 = "ts2.1";
+	}
 }
 
 export interface TypingsData extends PackageCommonProperties {

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -67,7 +67,8 @@ export async function getTypingInfo(folderName: string, options: Options): Promi
 	const mainFilename = "index.d.ts";
 	const mainFileContent = await readFile(directory, mainFilename);
 
-	const { authors, libraryMajorVersion, libraryMinorVersion, libraryName, projects } = parseHeaderOrFail(mainFileContent, folderName);
+	const { authors, libraryMajorVersion, libraryMinorVersion, typeScriptVersion, libraryName, projects } =
+		parseHeaderOrFail(mainFileContent, folderName);
 
 	const allEntryFilenames = await entryFilesFromTsConfig(directory, log) || [mainFilename];
 	const { referencedLibraries, moduleDependencies, globalSymbols, declaredModules, declFiles } =
@@ -83,6 +84,7 @@ export async function getTypingInfo(folderName: string, options: Options): Promi
 		moduleDependencies,
 		libraryMajorVersion,
 		libraryMinorVersion,
+		typeScriptVersion,
 		libraryName,
 		typingsPackageName: folderName,
 		projectName: projects[0], // TODO: collect multiple project names

--- a/src/lib/header.ts
+++ b/src/lib/header.ts
@@ -1,5 +1,6 @@
-import { intOfString } from "../util/util";
 import pm = require("parsimmon");
+import { intOfString } from "../util/util";
+import { TypeScriptVersion } from "./common";
 
 /*
 Example:
@@ -7,12 +8,14 @@ Example:
 // Project: https://github.com/foo/foo, https://foo.com
 // Definitions by: My Self <https://github.com/me>, Some Other Guy <https://github.com/otherguy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 */
 
 export interface Header {
 	libraryName: string;
 	libraryMajorVersion: number;
 	libraryMinorVersion: number;
+	typeScriptVersion: TypeScriptVersion;
 	projects: string[];
 	authors: Author[];
 }
@@ -56,14 +59,14 @@ function parseHeader(text: string, strict: boolean): Header | ParseError {
 	const res = headerParser(strict).parse(text);
 
 	if (res.status) {
-		const { label: { name, major, minor }, projects, authors } = res.value!;
-		return { libraryName: name, libraryMajorVersion: major, libraryMinorVersion: minor, projects, authors };
+		const { label: { name, major, minor }, projects, authors, typeScriptVersion } = res.value!;
+		return { libraryName: name, libraryMajorVersion: major, libraryMinorVersion: minor, projects, authors, typeScriptVersion };
 	}
 	// parsimmon types are wrong: expected is actually string[]
 	return { index: res.index!.offset, line: res.index!.line, column: res.index!.column, expected: res.expected as any as string[] };
 }
 
-function headerParser(strict: boolean): pm.Parser<{ label: Label, projects: string[], authors: Author[] }> {
+function headerParser(strict: boolean): pm.Parser<{ label: Label, projects: string[], authors: Author[], typeScriptVersion: TypeScriptVersion }> {
 	return pm.seqMap(
 		pm.string("// Type definitions for "),
 		parseLabel(strict),
@@ -72,9 +75,10 @@ function headerParser(strict: boolean): pm.Parser<{ label: Label, projects: stri
 		pm.regexp(/\r?\n\/\/ Definitions by: /),
 		authorsParser(strict),
 		parseDefinitions,
+		parseTypeScriptVersion,
 		pm.all, // Don't care about the rest of the file
 		// tslint:disable-next-line:variable-name
-		(_str, label, _project, projects, _defsBy, authors) => ({ label, projects, authors }));
+		(_str, label, _project, projects, _defsBy, authors, _definitions, typeScriptVersion) => ({ label, projects, authors, typeScriptVersion }));
 }
 
 interface Label { name: string; major: number; minor: number; }
@@ -168,6 +172,11 @@ function parseLabel(strict: boolean): pm.Parser<Label> {
 	});
 }
 
+const parseTypeScriptVersion: pm.Parser<TypeScriptVersion> =
+	pm.regexp(/\r?\n\/\/ TypeScript Version: 2.1/)
+		.result<TypeScriptVersion>("2.1")
+		.fallback<TypeScriptVersion>("2.0");
+
 function reverse(s: string): string {
 	let out = "";
 	for (let i = s.length - 1; i >= 0; i--) {
@@ -187,7 +196,11 @@ declare module "parsimmon" {
 	export function makeFailure(index: number, expected: string): pm.Result<any>;
 
 	export function sepBy1<T>(a: pm.Parser<T>, b: pm.Parser<any>): Parser<T[]>;
-	export function seqMap<T, U, V, W, X, Y, Z, AA, BB>(
-		p1: Parser<T>, p2: Parser<U>, p3: Parser<V>, p4: Parser<W>, p5: Parser<X>, p6: Parser<Y>, p7: Parser<Z>, p8: Parser<AA>,
-		cb: (a1: T, a2: U, a3: V, a4: W, a5: X, a6: Y, a7: Z, a8: AA) => BB): Parser<BB>;
+	export function seqMap<T, U, V, W, X, Y, Z, AA, BB, CC>(
+		p1: Parser<T>, p2: Parser<U>, p3: Parser<V>, p4: Parser<W>, p5: Parser<X>, p6: Parser<Y>, p7: Parser<Z>, p8: Parser<AA>, p9: Parser<BB>,
+		cb: (a1: T, a2: U, a3: V, a4: W, a5: X, a6: Y, a7: Z, a8: AA, a9: BB) => CC): Parser<CC>;
+
+	export interface Parser<T> {
+		fallback<U>(value: U): Parser<T | U>;
+	}
 }

--- a/src/lib/package-generator.ts
+++ b/src/lib/package-generator.ts
@@ -131,7 +131,8 @@ async function createPackageJSON(typing: TypingsData, { version, contentHash }: 
 		scripts: {},
 		dependencies,
 		peerDependencies,
-		typesPublisherContentHash: contentHash
+		typesPublisherContentHash: contentHash,
+		typeScriptVersion: typing.typeScriptVersion
 	};
 
 	return JSON.stringify(out, undefined, 4);

--- a/src/lib/package-publisher.ts
+++ b/src/lib/package-publisher.ts
@@ -1,11 +1,12 @@
 import assert = require("assert");
 import * as path from "path";
 
+import { addNpmTagsForPackage } from "../npmTags";
 import { readJson } from "../util/io";
 import { consoleLogger, quietLogger, Log, LoggerWithErrors } from "../util/logging";
 import { exec } from "../util/util";
 
-import { AnyPackage, fullPackageName, isNotNeededPackage, notNeededReadme, settings } from "./common";
+import { AnyPackage, fullPackageName, isNotNeededPackage, notNeededReadme } from "./common";
 import NpmClient from "./npm-client";
 
 export async function publishPackage(client: NpmClient, pkg: AnyPackage, dry: boolean): Promise<Log> {
@@ -20,9 +21,7 @@ export async function publishPackage(client: NpmClient, pkg: AnyPackage, dry: bo
 	assert(typeof version === "string");
 
 	await client.publish(packageDir, packageJson, dry);
-	if (settings.tag && settings.tag !== "latest" && !dry) { // "latest" is the default tag anyway
-		await client.tag(name, version, settings.tag);
-	}
+	await addNpmTagsForPackage(pkg, version, client, log, dry);
 
 	if (isNotNeededPackage(pkg)) {
 		log(`Deprecating ${name}`);

--- a/src/npmTags.ts
+++ b/src/npmTags.ts
@@ -1,0 +1,51 @@
+import * as yargs from "yargs";
+
+import { AnyPackage, Options, TypeScriptVersion, existsTypesDataFileSync, fullPackageName, readAllPackages } from "./lib/common";
+import NpmClient from "./lib/npm-client";
+import Versions, { versionString } from "./lib/versions";
+
+import { Logger } from "./util/logging";
+import { done } from "./util/util";
+
+if (!module.parent) {
+	if (!existsTypesDataFileSync()) {
+		console.log("Run parse-definitions first!");
+	}
+	else if (!Versions.existsSync()) {
+		console.log("Run calculate-versions first!");
+	}
+	else {
+		const dry = !!yargs.argv.dry;
+		done(tagAll(Options.defaults, dry));
+	}
+}
+
+/**
+ * Refreshes the tags on every package.
+ * This shouldn't normally need to run, since we run `tagSingle` whenever we publish a package.
+ * But this should be run if the way we calculate tags changes (e.g. when a new release is allowed to be tagged "latest").
+ */
+async function tagAll(options: Options, dry: boolean) {
+	const versions = await Versions.load();
+	const client = await NpmClient.create();
+
+	const { typings, notNeeded } = await readAllPackages(options);
+
+	for (const t of typings) {
+		const version = versionString(versions.versionInfo(t).version);
+		await addNpmTagsForPackage(t, version, client, console.log, dry);
+	}
+
+	//TODO: Do it for notNeeded too!
+	notNeeded;
+}
+
+export async function addNpmTagsForPackage(pkg: AnyPackage, version: string, client: NpmClient, log: Logger, dry: boolean): Promise<void> {
+	const tags = TypeScriptVersion.tagsToUpdate(pkg.packageKind === "not-needed" ? "2.0" : pkg.typeScriptVersion);
+	log(`Tag ${fullPackageName(pkg.typingsPackageName)}@${version} as ${JSON.stringify(tags)}`);
+	if (!dry) {
+		for (const tag of tags) {
+			await client.tag(fullPackageName(pkg.typingsPackageName), version, tag);
+		}
+	}
+}

--- a/src/publish-registry.ts
+++ b/src/publish-registry.ts
@@ -72,7 +72,7 @@ async function publish(packageJson: {}, dry: boolean): Promise<void> {
 }
 
 async function fetchLastPatchNumber(): Promise<number> {
-	return (await fetchVersionInfoFromNpm(packageName))!.version.patch;
+	return (await fetchVersionInfoFromNpm(packageName, /*isPrerelease*/ false))!.version.patch;
 }
 
 function generatePackageJson(patch: number): {} {

--- a/src/settings.d.ts
+++ b/src/settings.d.ts
@@ -16,9 +16,6 @@ interface PublishSettings {
 	// The branch that DefinitelyTyped is sourced from
 	sourceBranch: string;
 
-	// e.g. 'latest'
-	tag?: string;
-
 	// Name of the azure storage account. Used for uploading data and logs.
 	azureStorageAccount: string;
 

--- a/src/tester/ts-installer.ts
+++ b/src/tester/ts-installer.ts
@@ -1,0 +1,38 @@
+import * as fsp from "fs-promise";
+import * as path from "path";
+
+import { TypeScriptVersion } from "../lib/common";
+import { writeJson } from "../util/io";
+import { execAndThrowErrors } from "../util/util";
+
+const installsDir = "typescript-installs";
+
+export async function installAllTypeScriptVersions(): Promise<void> {
+	console.log("Installing TypeScript versions...");
+
+	await fsp.mkdirp(installsDir);
+	for (const version of TypeScriptVersion.All) {
+		const dir = installDir(version);
+		await fsp.mkdirp(dir);
+		writeJson(path.join(dir, "package.json"), packageJson(version));
+		await execAndThrowErrors("npm install", dir);
+	}
+}
+
+export function pathToTsc(version: TypeScriptVersion): string {
+	return path.join(__dirname, "..", "..", installDir(version), "node_modules", "typescript", "lib", "tsc.js");
+}
+
+function installDir(version: TypeScriptVersion) {
+	return path.join(installsDir, version);
+}
+
+function packageJson(version: TypeScriptVersion): {} {
+	return {
+		name: "ts-install",
+		version: "0.0.0",
+		dependencies: {
+			typescript: `${version}.x`
+		}
+	};
+}

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -2,7 +2,7 @@ import * as fsp from "fs-promise";
 import * as path from "path";
 import * as yargs from "yargs";
 
-import { Options, existsTypesDataFileSync, settings, readAllPackagesArray, readTypings } from "./lib/common";
+import { Options, existsTypesDataFileSync, fullPackageName, settings, readAllPackagesArray, readTypings } from "./lib/common";
 import { writeFile, writeJson } from "./util/io";
 import { LoggerWithErrors, quietLoggerWithErrors, loggerWithErrors, moveLogsWithErrors, writeLog } from "./util/logging";
 import { done, exec, nAtATime } from "./util/util";
@@ -128,7 +128,7 @@ async function writePackage(packageDirectory: string, packageName: string) {
 		author: "",
 		license: "ISC",
 		repository: "https://github.com/Microsoft/types-publisher",
-		dependencies: { [`@types/${packageName}`]: settings.tag }
+		dependencies: { [fullPackageName(packageName)]: "latest" }
 	});
 
 	// Write tsconfig.json

--- a/tslint-common.json
+++ b/tslint-common.json
@@ -30,7 +30,7 @@
 		"object-literal-sort-keys": false,
 		"one-variable-per-declaration": false,
 		"ordered-imports": false,
-		"prefer-for-of": false, // Enable when https://github.com/palantir/tslint/pull/1758 is in
+		"switch-default": false,
 		"trailing-comma": false
     }
 }


### PR DESCRIPTION
Fixes #214

* Add a `typeScriptVersion` property for each definition. This may be overridden by an extra line added to the header.
* If we deem it a prerelease version, publish it as MAJOR.MINOR.0-next.PATCH
* Install multiple typescript versions, so we use the appropriate one for tests.
* Add a script for tagging all packages when we make a change. Normally, just tag a package when publishing it.