### PR TITLE
Update tslint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "semver": "^5.3.0",
     "source-map-support": "^0.4.0",
     "tar": "^2.2.1",
-    "tslint": "next",
+    "tslint": "^4.1.0",
     "typescript": "^2.0.10",
     "yargs": "^6.2.0"
   },


### PR DESCRIPTION
"next" points at the previous prerelease version, but 4.1.0 is actually newer.