### PR TITLE
Upgrade handling of not-found packages on NPM

### DIFF
--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -110,15 +110,10 @@ export async function fetchVersionInfoFromNpm(escapedPackageName: string, newMaj
 	const info = await fetchJson(uri, { retries: true });
 
 	if (info.error) {
-		if (info.error === "Not found") {
-			return undefined;
-		}
-		else {
-			throw new Error(`Error getting version at ${uri}: ${info.error}`);
-		}
+		throw new Error(`Error getting version at ${uri}: ${info.error}`);
 	}
-	// Kludge: NPM started returning `{}` for not-found @types packages. Should be able to remove this case once that behavior is changed.
 	else if (!info["dist-tags"]) {
+		// NPM returns `{}` for missing packages.
 		return undefined;
 	}
 	else {


### PR DESCRIPTION
Looks like the old "kludge" is the way NPM works now.