### PR TITLE
Exclude NPM checks from check-parse-results when run as part of a test/publish

### DIFF
--- a/src/check-parse-results.ts
+++ b/src/check-parse-results.ts
@@ -6,18 +6,20 @@ import { fetchJson} from "./util/io";
 import { best, done, nAtATime } from "./util/util";
 
 if (!module.parent) {
-	done(main());
+	done(main(true));
 }
 
-export default async function main(): Promise<void> {
+export default async function main(includeNpmChecks: boolean): Promise<void> {
 	const packages = await AllPackages.readTypings();
 	const [log, logResult] = logger();
 	check(packages, info => info.libraryName, "Library Name", log);
 	check(packages, info => info.projectName, "Project Name", log);
-	await nAtATime(10, packages, pkg => checkNpm(pkg, log), {
-		name: "Checking for typed packages...",
-		flavor: pkg => pkg.typingsPackageName
-	});
+	if (includeNpmChecks) {
+		await nAtATime(10, packages, pkg => checkNpm(pkg, log), {
+			name: "Checking for typed packages...",
+			flavor: pkg => pkg.typingsPackageName
+		});
+	}
 	await writeLog("conflicts.md", logResult());
 }
 

--- a/src/full.ts
+++ b/src/full.ts
@@ -25,7 +25,7 @@ export default async function full(client: NpmClient, dry: boolean, timeStamp: s
 	await clean();
 	await getDefinitelyTyped(options);
 	await parseDefinitions(options);
-	await checkParseResults();
+	await checkParseResults(/*includeNpmChecks*/ false);
 	await calculateVersions(/*forceUpdate*/ false, options);
 	await generatePackages(options);
 	await createSearchIndex(/*skipDownloads*/ false, /*full*/ false);

--- a/src/tester/test.ts
+++ b/src/tester/test.ts
@@ -16,6 +16,6 @@ if (!module.parent) {
 async function main(options: Options, nProcesses?: number): Promise<void> {
 	await clean();
 	await parseDefinitions(options);
-	await checkParseResults();
+	await checkParseResults(/*includeNpmChecks*/false);
 	await runTests(options, nProcesses);
 }


### PR DESCRIPTION
We can still run this manually, but it's slowing down test/publish and I already have a list of packages to work on, so it's not really helpful to get it again every time.
This could be much faster if we hosted the list of typed packages from #260 somewhere and just compared against that.