### PR TITLE
get-affected-packages: If a package doesn't exist, OK, don't throw an error.

### DIFF
--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -49,11 +49,16 @@ export class AllPackages {
 	}
 
 	getLatestVersion(packageName: string): TypingsData {
-		const versions = this.data.get(packageName);
-		if (!versions) {
+		const latest = this.tryGetLatestVersion(packageName);
+		if (!latest) {
 			throw new Error(`No such package ${packageName}.`);
 		}
-		return versions.getLatest();
+		return latest;
+	}
+
+	tryGetLatestVersion(packageName: string): TypingsData | undefined {
+		const versions = this.data.get(packageName);
+		return versions && versions.getLatest();
 	}
 
 	getTypingsData(id: PackageId) {


### PR DESCRIPTION
Fixes tests for DefinitelyTyped/DefinitelyTyped#13919