### PR TITLE
Allow packages to opt-in to typings-checker instead of tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "tar": "^2.2.1",
     "tslint": "^4.2.0",
     "typescript": "next",
+    "typings-checker": "^1.1.1",
     "yargs": "^6.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Just throwing this out there to get some feedback. See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/1572#issuecomment-272571498

For packages that opt-in, this would let them run their tests through `typings-checker` instead of `tsc`. `typings-checker` lets allows errors to be marked as expected and lets tests make assertions about the types of symbols. This helps prevent unintended `any` or `{}` types from creeping in.