### PR TITLE
fix(diff): omit removed files

### DIFF
--- a/src/tester/get-affected-packages.ts
+++ b/src/tester/get-affected-packages.ts
@@ -130,7 +130,7 @@ async function gitDiff(log: Logger, options: Options): Promise<string[]> {
 		// We are probably already on master, so compare to the last commit.
 		diff = (await run(`git diff ${sourceBranch}~1...HEAD --name-only`)).trim();
 	}
-	return diff.split("\n").map((fileName) => fs.existsSync(fileName));
+	return diff.split("\n").filter((fileName) => fs.existsSync(fileName));
 
 	async function run(cmd: string): Promise<string> {
 		log("Running: " + cmd);

--- a/src/tester/get-affected-packages.ts
+++ b/src/tester/get-affected-packages.ts
@@ -4,6 +4,7 @@ import { AllPackages, PackageBase, TypingsData } from "../lib/packages";
 import { sourceBranch } from "../lib/settings";
 import { Logger } from "../util/logging";
 import { done, execAndThrowErrors, flatMap, map, mapDefined, join, sort } from "../util/util";
+import * as fs from "fs";
 
 if (!module.parent) {
 	done(main(Options.defaults));
@@ -129,7 +130,7 @@ async function gitDiff(log: Logger, options: Options): Promise<string[]> {
 		// We are probably already on master, so compare to the last commit.
 		diff = (await run(`git diff ${sourceBranch}~1...HEAD --name-only`)).trim();
 	}
-	return diff.split("\n");
+	return diff.split("\n").map((fileName) => fs.existsSync(fileName));
 
 	async function run(cmd: string): Promise<string> {
 		log("Running: " + cmd);


### PR DESCRIPTION
This will avoid throw error when remove a version's typings definitions.