### PR TITLE
Support types being in a "types" directory of DefinitelyTyped, as opposed to at the root

### DIFF
--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -2,6 +2,7 @@ import * as fsp from "fs-promise";
 
 import { readJson, writeJson } from "../util/io";
 import { joinPaths } from "../util/util";
+import { typesDirectoryName } from "../lib/settings";
 
 if (process.env.LONGJOHN) {
 	console.log("=== USING LONGJOHN ===");
@@ -12,25 +13,23 @@ if (process.env.LONGJOHN) {
 export const home = joinPaths(__dirname, "..", "..");
 
 /** Settings that may be determined dynamically. */
-export interface Options {
-	// e.g. '../DefinitelyTyped'
-	// This is overridden to `cwd` when running the tester, as that is run from within DefinitelyTyped.
-	definitelyTypedPath: string;
-
-	// Whether to show progress bars. Good when running locally, bad when running on travis / azure.
-	progress: boolean;
-}
-export namespace Options {
+export class Options {
 	/** Options for running locally. */
-	export const defaults: Options = {
-		definitelyTypedPath: "../DefinitelyTyped",
-		progress: true
-	};
+	static defaults = new Options("../DefinitelyTyped", true);
+	static azure = new Options("../DefinitelyTyped", false);
 
-	export const azure: Options = {
-		definitelyTypedPath: "../DefinitelyTyped",
-		progress: false
-	};
+	/** Location of all types packages. This is a subdirectory of DefinitelyTyped. */
+	readonly typesPath: string;
+	constructor(
+		/** e.g. '../DefinitelyTyped'
+		 * This is overridden to `cwd` when running the tester, as that is run from within DefinitelyTyped.
+		 */
+		readonly definitelyTypedPath: string,
+		/** Whether to show progress bars. Good when running locally, bad when running on travis / azure. */
+		readonly progress: boolean) {
+
+		this.typesPath = joinPaths(definitelyTypedPath, typesDirectoryName);
+	}
 }
 
 export function readDataFile(generatedBy: string, fileName: string): Promise<any> {
@@ -55,8 +54,4 @@ export async function writeDataFile(filename: string, content: {}, formatted = t
 const dataDir = joinPaths(home, "data");
 function dataFilePath(filename: string) {
 	return joinPaths(dataDir, filename);
-}
-
-export function isTypingDirectory(directoryName: string) {
-	return directoryName !== "node_modules" && directoryName !== "scripts";
 }

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -404,7 +404,7 @@ export class TypingsData extends PackageBase {
 	}
 
 	directoryPath(options: Options): string {
-		return joinPaths(options.definitelyTypedPath, this.subDirectoryPath);
+		return joinPaths(options.typesPath, this.subDirectoryPath);
 	}
 
 	filePath(fileName: string, options: Options): string {
@@ -435,7 +435,7 @@ async function readNotNeededPackages(options: Options): Promise<NotNeededPackage
 
 /** Path to the *root* for a given package. Path to a particular version may differ. */
 export function packageRootPath(packageName: string, options: Options): string {
-	return joinPaths(options.definitelyTypedPath, packageName);
+	return joinPaths(options.typesPath, packageName);
 }
 
 export type TypeScriptVersion = "2.0" | "2.1" | "2.2";

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -17,3 +17,5 @@ export const azureContainer = "typespublisher";
 export const azureKeyvault = "https://types-publisher-keys.vault.azure.net";
 /** Issue in types-publisher that we will use to report webhook errors. */
 export const errorsIssue = "Microsoft/types-publisher/issues/40";
+
+export const typesDirectoryName = "types";

--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -32,7 +32,7 @@ export function parseNProcesses(): number | undefined {
 
 export function testerOptions(runFromDefinitelyTyped: boolean): Options {
 	if (runFromDefinitelyTyped) {
-		return { definitelyTypedPath: process.cwd(), progress: false };
+		return new Options(process.cwd(), false);
 	} else {
 		return Options.defaults;
 	}

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -66,11 +66,6 @@ export async function filterNAtATime<T>(
 	return inputs.filter((_, idx) => shouldKeeps[idx]);
 }
 
-export async function filterAsyncOrdered<T>(arr: T[], shouldKeep: (t: T) => Promise<boolean>): Promise<T[]> {
-	const shouldKeeps: boolean[] = await Promise.all(arr.map(shouldKeep));
-	return arr.filter((_, idx) => shouldKeeps[idx]);
-}
-
 export async function mapAsyncOrdered<T, U>(arr: T[], mapper: (t: T) => Promise<U>): Promise<U[]> {
 	const out = new Array(arr.length);
 	await Promise.all(arr.map(async (em, idx) => {


### PR DESCRIPTION
This should wait for the change to be done in DefinitelyTyped.

That can be done with a script:

```ts
// Usage: ts-node mv.ts
/// <reference types="node" />
import * as fs from 'fs';
import * as path from 'path';

const home = path.join(__dirname, '..');

fs.mkdirSync(path.join(home, "types"));

for (const dirName of fs.readdirSync(home)) {
    if (dirName.startsWith(".") || dirName === "node_modules" || dirName === "scripts" || dirName === "types") {
        continue;
    }

    if (fs.statSync(path.join(home, dirName)).isDirectory()) {
        fs.renameSync(path.join(home, dirName), path.join(home, "types", dirName));
    }
}
```