### PR TITLE
Use execSync for get-definitely-typed

### DIFF
--- a/src/get-definitely-typed.ts
+++ b/src/get-definitely-typed.ts
@@ -1,9 +1,10 @@
 import * as fsp from "fs-promise";
+import { execSync } from "child_process";
 import { dirname } from "path";
 
 import { Options } from "./lib/common";
 import { sourceBranch, sourceRepository } from "./lib/settings";
-import { done, execAndThrowErrors as exec } from "./util/util";
+import { done } from "./util/util";
 
 if (!module.parent) {
 	done(main(Options.defaults));
@@ -15,21 +16,29 @@ export default async function main(options: Options): Promise<void> {
 	if (await fsp.exists(options.definitelyTypedPath)) {
 		console.log(`Fetching changes from ${sourceBranch}`);
 
-		const actualBranch = await exec(`git rev-parse --abbrev-ref HEAD`, dtPath);
+		const actualBranch = exec(`git rev-parse --abbrev-ref HEAD`, dtPath);
 		if (actualBranch !== sourceBranch) {
 			throw new Error(`Please checkout branch '${sourceBranch}`);
 		}
 
-		const diff = await exec(`git diff --name-only`, dtPath);
+		const diff = exec(`git diff --name-only`, dtPath);
 		if (diff) {
 			throw new Error(`'git diff' should be empty. Following files changed:\n${diff}`);
 		}
 
-		await exec(`git pull`, dtPath);
+		exec(`git pull`, dtPath);
 	}
 	else {
 		console.log(`Cloning ${sourceRepository} to ${dtPath}`);
-		await exec(`git clone ${sourceRepository}`, dirname(dtPath));
-		await exec(`git checkout ${sourceBranch}`, dtPath);
+		exec(`git clone ${sourceRepository}`, dirname(dtPath));
+		exec(`git checkout ${sourceBranch}`, dtPath);
 	}
+}
+
+
+function exec(cmd: string, cwd?: string): string {
+	console.log(`Exec${cwd ? " at " + cwd : ""}: ${cmd}`);
+	const result = execSync(cmd, { cwd, encoding: "utf8" }).trim();
+	console.log(result);
+	return result.trim();
 }


### PR DESCRIPTION
Azure was hanging indefinitely (5min+) when using the async version. This seems to fix it.