### PR TITLE
Track references in test files and warn on unnecessary references

### DIFF
--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -7,7 +7,7 @@ import { computeHash, hasWindowsSlashes, join, joinPaths, mapAsyncOrdered } from
 
 import { Options } from "./common";
 import { parseHeaderOrFail } from "./header";
-import getModuleInfo from "./module-info";
+import getModuleInfo, { getTestDependencies } from "./module-info";
 import { DependenciesRaw, PathMappingsRaw, TypingsDataRaw, TypingsVersionsRaw, packageRootPath } from "./packages";
 
 export async function getTypingInfo(packageName: string, options: Options): Promise<{ data: TypingsVersionsRaw, logs: Log }> {
@@ -91,6 +91,7 @@ async function getTypingData(packageName: string, directory: string, ls: string[
 	const tsconfig: TsConfig = await fsp.readJSON(joinPaths(directory, "tsconfig.json"));
 	const { typeFiles, testFiles } = await entryFilesFromTsConfig(packageName, directory, tsconfig);
 	const { dependencies: dependenciesSet, globals, declaredModules, declFiles } = await getModuleInfo(packageName, directory, typeFiles, log);
+	const testDependencies = await getTestDependencies(packageName, directory, testFiles, dependenciesSet);
 	const { dependencies, pathMappings } = await calculateDependencies(packageName, tsconfig, dependenciesSet, oldMajorVersion);
 
 	const hasPackageJson = await fsp.exists(joinPaths(directory, "package.json"));
@@ -111,6 +112,7 @@ async function getTypingData(packageName: string, directory: string, ls: string[
 	const data: TypingsDataRaw = {
 		contributors,
 		dependencies,
+		testDependencies,
 		pathMappings,
 		libraryMajorVersion,
 		libraryMinorVersion,

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -105,6 +105,18 @@ export class AllPackages {
 			}
 		}
 	}
+
+	/** Like 'dependencyTypings', but includes test dependencies. */
+	*allDependencyTypings(pkg: TypingsData): Iterable<TypingsData> {
+		yield* this.dependencyTypings(pkg);
+
+		for (const name of pkg.testDependencies) {
+			const versions = this.data.get(name);
+			if (versions) {
+				yield versions.getLatest();
+			}
+		}
+	}
 }
 
 export const typesDataFilename = "definitions.json";
@@ -261,6 +273,9 @@ export type DependencyVersion = number | "*";
 
 export interface TypingsDataRaw extends BaseRaw {
 	readonly dependencies: DependenciesRaw;
+	 // These are always the latest version.
+	 // Will not include anything already in `dependencies`.
+	readonly testDependencies: string[];
 	readonly pathMappings: PathMappingsRaw;
 
 	// Parsed from "Definitions by:"
@@ -351,6 +366,7 @@ export class TypingsData extends PackageBase {
 		super(data);
 	}
 
+	get testDependencies(): string[] { return this.data.testDependencies; }
 	get contributors(): Contributor[] { return this.data.contributors; }
 	get major(): number { return this.data.libraryMajorVersion; }
 	get minor(): number { return this.data.libraryMinorVersion; }

--- a/src/tester/get-affected-packages.ts
+++ b/src/tester/get-affected-packages.ts
@@ -71,7 +71,7 @@ function getReverseDependencies(allPackages: AllPackages): Map<TypingsData, Set<
 	}
 
 	for (const typing of allPackages.allTypings()) {
-		for (const dependency of allPackages.dependencyTypings(typing)) {
+		for (const dependency of allPackages.allDependencyTypings(typing)) {
 			map.get(dependency)!.add(typing);
 		}
 	}

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -83,14 +83,6 @@ export function indent(str: string): string {
 	return "\t" + str.replace(/\n/g, "\n\t");
 }
 
-export function stripQuotes(s: string): string {
-	if (s[0] === '"' || s[0] === "'") {
-		return s.substr(1, s.length - 2);
-	} else {
-		throw new Error(`${s} is not quoted`);
-	}
-}
-
 export function unique<T>(arr: T[]) {
 	return [...new Set(arr)];
 }


### PR DESCRIPTION
Don't allow `/// <reference path="" />` in test files.
Don't allow `/// <reference types="foo" />` in a test file if it is already referenced in a definition file, or if `foo` is the name of the current package.
Track all test references so that when a package changes, we test *all* packages that depend on it, whether through a definition or through a test.
