### PR TITLE
Fix handling of test dependencies

### DIFF
--- a/src/check-parse-results.ts
+++ b/src/check-parse-results.ts
@@ -56,7 +56,7 @@ function checkPathMappings(allPackages: AllPackages) {
 		const unusedPathMappings = new Set(pathMappings.keys());
 
 		// If A depends on B, and B has path mappings, A must have the same mappings.
-		for (const dependency of allPackages.dependencyTypings(pkg)) {
+		for (const dependency of allPackages.allDependencyTypings(pkg)) {
 			for (const [name, dependencyMappingVersion] of dependency.pathMappings) {
 				if (pathMappings.get(name) !== dependencyMappingVersion) {
 					throw new Error(

--- a/src/parse-definitions.ts
+++ b/src/parse-definitions.ts
@@ -57,5 +57,5 @@ async function single(singleName: string, options: Options): Promise<void> {
 	const result = await parser.getTypingInfo(singleName, options);
 	const typings = { [singleName]: result.data };
 	await writeDataFile(typesDataFilename, typings);
-	console.log(result);
+	console.log(JSON.stringify(result, undefined, 4));
 }

--- a/src/tester/get-affected-packages.ts
+++ b/src/tester/get-affected-packages.ts
@@ -23,11 +23,6 @@ export default async function getAffectedPackages(allPackages: AllPackages, log:
 	return collectDependers(changedPackages, dependedOn);
 }
 
-/** Every package name in the original list, plus their dependencies (incl. dependencies' dependencies). */
-export function allDependencies(allPackages: AllPackages, packages: TypingsData[]): TypingsData[] {
-	return sortPackages(transitiveClosure(packages, pkg => allPackages.dependencyTypings(pkg)));
-}
-
 /** Collect all packages that depend on changed packages, and all that depend on those, etc. */
 function collectDependers(changedPackages: Iterable<TypingsData>, reverseDependencies: Map<TypingsData, Set<TypingsData>>): TypingsData[] {
 	return sortPackages(transitiveClosure(changedPackages, pkg => reverseDependencies.get(pkg) || []));
@@ -124,10 +119,10 @@ async function gitDiff(log: Logger, options: Options): Promise<string[]> {
 
 	// `git diff foo...bar` gets all changes from X to `bar` where X is the common ancestor of `foo` and `bar`.
 	// Source: https://git-scm.com/docs/git-diff
-	let diff = (await run(`git diff ${sourceBranch}...HEAD --name-only`)).trim();
+	let diff = (await run(`git diff ${sourceBranch} --name-only`)).trim();
 	if (diff === "") {
 		// We are probably already on master, so compare to the last commit.
-		diff = (await run(`git diff ${sourceBranch}~1...HEAD --name-only`)).trim();
+		diff = (await run(`git diff ${sourceBranch}~1 --name-only`)).trim();
 	}
 	return diff.split("\n");
 

--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -8,7 +8,7 @@ import { readJson } from "../util/io";
 import { LoggerWithErrors, moveLogsWithErrors, quietLoggerWithErrors } from "../util/logging";
 import { done, exec, execAndThrowErrors, joinPaths, nAtATime, numberOfOsProcesses } from "../util/util";
 
-import getAffectedPackages, { allDependencies } from "./get-affected-packages";
+import getAffectedPackages from "./get-affected-packages";
 import { installAllTypeScriptVersions, pathToTsc } from "./ts-installer";
 
 const tslintPath = joinPaths(require.resolve("tslint"), "../tslint-cli.js");
@@ -55,7 +55,7 @@ export default async function main(options: Options, nProcesses?: number, regexp
 
 	console.log("Installing dependencies...");
 
-	await nAtATime(nProcesses, allDependencies(allPackages, typings), async pkg => {
+	await nAtATime(nProcesses, typings, async pkg => {
 		const cwd = pkg.directoryPath(options);
 		if (await fsp.exists(joinPaths(cwd, "package.json"))) {
 			let stdout = await execAndThrowErrors(`npm install`, cwd);


### PR DESCRIPTION
Continuation of #315
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/14557#issuecomment-286829607

* Don't use `.imports` because that's not set. Use our code for walking the tree to find imports.
* Use `.allDependencyTypes` instead of `.dependencyTypes` in check-parse-results and get-affected-packages