### PR TITLE
Reintroduce allDependencies properly

### DIFF
--- a/src/tester/get-affected-packages.ts
+++ b/src/tester/get-affected-packages.ts
@@ -23,6 +23,11 @@ export default async function getAffectedPackages(allPackages: AllPackages, log:
 	return collectDependers(changedPackages, dependedOn);
 }
 
+/** Every package name in the original list, plus their dependencies (incl. dependencies' dependencies). */
+export function allDependencies(allPackages: AllPackages, packages: TypingsData[]): TypingsData[] {
+	return sortPackages(transitiveClosure(packages, pkg => allPackages.allDependencyTypings(pkg)));
+}
+
 /** Collect all packages that depend on changed packages, and all that depend on those, etc. */
 function collectDependers(changedPackages: Iterable<TypingsData>, reverseDependencies: Map<TypingsData, Set<TypingsData>>): TypingsData[] {
 	return sortPackages(transitiveClosure(changedPackages, pkg => reverseDependencies.get(pkg) || []));

--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -8,7 +8,7 @@ import { readJson } from "../util/io";
 import { LoggerWithErrors, moveLogsWithErrors, quietLoggerWithErrors } from "../util/logging";
 import { done, exec, execAndThrowErrors, joinPaths, nAtATime, numberOfOsProcesses } from "../util/util";
 
-import getAffectedPackages from "./get-affected-packages";
+import getAffectedPackages, { allDependencies } from "./get-affected-packages";
 import { installAllTypeScriptVersions, pathToTsc } from "./ts-installer";
 
 const tslintPath = joinPaths(require.resolve("tslint"), "../tslint-cli.js");
@@ -55,7 +55,8 @@ export default async function main(options: Options, nProcesses?: number, regexp
 
 	console.log("Installing dependencies...");
 
-	await nAtATime(nProcesses, typings, async pkg => {
+	// We need to run `npm install` for all dependencies, too, so that we have dependencies' dependencies installed.
+	await nAtATime(nProcesses, allDependencies(allPackages, typings), async pkg => {
 		const cwd = pkg.directoryPath(options);
 		if (await fsp.exists(joinPaths(cwd, "package.json"))) {
 			let stdout = await execAndThrowErrors(`npm install`, cwd);


### PR DESCRIPTION
Should have documented why this function existed. Shouldn't have removed in #321.
Note: used `.dependencyTypings` before, now uses `.allDependencyTypings`, so we `npm install` on test dependencies too.