### PR TITLE
fix(package generator): incorrect exported path

### DIFF
--- a/src/lib/package-generator.ts
+++ b/src/lib/package-generator.ts
@@ -179,7 +179,7 @@ function createReadme(typing: TypingsData) {
 	lines.push("");
 
 	lines.push("# Details");
-	lines.push(`Files were exported from ${typing.sourceRepoURL}/tree/${sourceBranch}/${typing.subDirectoryPath}`);
+	lines.push(`Files were exported from ${typing.sourceRepoURL}/tree/${sourceBranch}/types/${typing.subDirectoryPath}`);
 
 	lines.push("");
 	lines.push(`Additional Details`);


### PR DESCRIPTION
At the moment the path is "Files were exported from `https://www.github.com/DefinitelyTyped/DefinitelyTyped/tree/master/stylelint`" however the path should be `https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/stylelint`

Note: missing `/types`