### PR TITLE
ignore .DS_Store files

### DIFF
--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -320,7 +320,7 @@ async function checkAllUsedRecur(directory: string, ls: Iterable<string>, usedFi
 			}
 			await checkAllUsedRecur(subdir, lssubdir, takeSubdirectoryOutOfSet(usedFiles), takeSubdirectoryOutOfSet(unusedFiles));
 		} else {
-			if (lsEntry.toLowerCase() !== "readme.md" && lsEntry !== "NOTICE" && lsEntry !== ".editorconfig") {
+			if (lsEntry.toLowerCase() !== "readme.md" && lsEntry !== "NOTICE" && lsEntry !== ".editorconfig" && lsEntry !== ".DS_Store") {
 				throw new Error(`Directory ${directory} has unused file ${lsEntry}`);
 			}
 		}


### PR DESCRIPTION
finder randomly creates these files inside the folders and prevents tests from being run on osx