### PR TITLE
Remove explicit dependency on NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "longjohn": "^0.2.11",
     "moment": "^2.18.1",
     "node-fetch": "^1.6.3",
-    "npm": "^4.4.4",
     "npm-registry-client": "^8.1.0",
     "object.entries": "^1.0.3",
     "object.values": "^1.0.3",


### PR DESCRIPTION
This was causing errors during installation:

```
npm ERR! enoent ENOENT: no such file or directory, rename '/home/travis/build/DefinitelyTyped/DefinitelyTyped/node_modules/.staging/term-size-05f0ddbd' -> '/home/travis/build/DefinitelyTyped/DefinitelyTyped/node_modules/types-publisher/node_modules/npm/node_modules/update-notifier/node_modules/boxen/node_modules/term-size'
```