### PR TITLE
DefinitelyTyped no longer has its own tslint.json, and dtslint doesn't need "--dt" flag.

### DIFF
--- a/src/parse-definitions.ts
+++ b/src/parse-definitions.ts
@@ -28,10 +28,6 @@ export default async function main(options: Options): Promise<void> {
 
 	await nAtATime(1, packageNames, use, { name: "Parsing...", flavor: name => name, options });
 	async function use(packageName: string): Promise<void> {
-		if (packageName === "tslint.json") {
-			return;
-		}
-
 		const { data, logs } = await parser.getTypingInfo(packageName, options);
 		typings[packageName] = data;
 

--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -87,7 +87,7 @@ export default async function main(options: Options, nProcesses?: number, regexp
 			console.error(err.message);
 		}
 
-		console.error(`The following packages had errors: ${allErrors.map(e => e.pkg.name).join(", ")}`);
+		console.error(`The following packages had errors: ${allErrors.map(e => e.pkg.desc).join(", ")}`);
 
 		throw new Error("There was a test failure.");
 	}
@@ -96,7 +96,7 @@ export default async function main(options: Options, nProcesses?: number, regexp
 async function single(pkg: TypingsData, log: LoggerWithErrors, options: Options): Promise<TesterError | undefined> {
 	const cwd = pkg.directoryPath(options);
 	const shouldLint = await fsp.exists(joinPaths(cwd, "tslint.json"));
-	return runCommand(log, cwd, pathToDtsLint, "--dt", ...(shouldLint ? [] : ["--noLint"]));
+	return runCommand(log, cwd, pathToDtsLint, ...(shouldLint ? [] : ["--noLint"]));
 }
 
 interface TesterError {


### PR DESCRIPTION
Companion to Microsoft/dtslint#26