### PR TITLE
Fix too rigid dtslint path

### DIFF
--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -14,7 +14,7 @@ if (!module.parent) {
 	done(main(testerOptions(!!yargs.argv.runFromDefinitelyTyped), parseNProcesses(), selection, tsNext));
 }
 
-const pathToDtsLint = joinPaths(__dirname, "..", "..", "node_modules", "dtslint", "bin", "index.js");
+const pathToDtsLint = require.resolve("dtslint");
 
 export function parseNProcesses(): number {
 	const str = yargs.argv.nProcesses;


### PR DESCRIPTION
When installing `types-publisher` with e.g. yarn, or flattening the module tree, the hardcoded path will get invalid.

This uses node’s import machinery to find the path.

As dtslint’s `main` field in package.json points to `bin/index.js`, this will result in the right path.