### PR TITLE
Revert to "tar" version 2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -224,6 +224,11 @@
       "from": "bl@>=1.1.2 <1.2.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz"
     },
+    "block-stream": {
+      "version": "0.0.9",
+      "from": "block-stream@*",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+    },
     "boom": {
       "version": "2.10.1",
       "from": "boom@>=2.0.0 <3.0.0",
@@ -836,16 +841,6 @@
       "from": "minimist@>=0.0.1 <0.1.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
     },
-    "minipass": {
-      "version": "2.0.2",
-      "from": "minipass@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.0.2.tgz"
-    },
-    "minizlib": {
-      "version": "1.0.3",
-      "from": "minizlib@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.3.tgz"
-    },
     "mkdirp": {
       "version": "0.5.1",
       "from": "mkdirp@>=0.5.0 >=0.0.0 <1.0.0",
@@ -1273,9 +1268,9 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
     "tar": {
-      "version": "3.1.3",
-      "from": "tar@>=3.1.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-3.1.3.tgz"
+      "version": "2.2.1",
+      "from": "tar@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
     },
     "thenify": {
       "version": "3.2.1",
@@ -1433,11 +1428,6 @@
       "version": "3.2.1",
       "from": "y18n@>=3.2.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
-    },
-    "yallist": {
-      "version": "3.0.2",
-      "from": "yallist@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz"
     },
     "yargs": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "oboe": "^2.1.3",
     "semver": "^5.3.0",
     "source-map-support": "^0.4.0",
-    "tar": "^3.1.3",
+    "tar": "^2.2.1",
     "typescript": "next",
     "yargs": "^8.0.1"
   },


### PR DESCRIPTION
Version 3 needs `new` in front of `Pack()`, but that disagrees with the current typings.