### PR TITLE
fix: only directories are valid type roots

### DIFF
--- a/src/parse-definitions.ts
+++ b/src/parse-definitions.ts
@@ -1,4 +1,5 @@
-import { readdir } from "fs-extra";
+import { readdir, statSync } from "fs-extra";
+import * as path from "path";
 import * as yargs from "yargs";
 
 import { Options, writeDataFile } from "./lib/common";
@@ -19,7 +20,8 @@ export default async function main(options: Options): Promise<void> {
 	summaryLog("# Typing Publish Report Summary");
 	summaryLog(`Started at ${(new Date()).toUTCString()}`);
 
-	const packageNames = await readdir(options.typesPath);
+	let packageNames = await readdir(options.typesPath);
+	packageNames = packageNames.filter(packageName => statSync(path.join(options.typesPath, packageName)).isDirectory());
 
 	summaryLog(`Found ${packageNames.length} typings folders in ${options.typesPath}`);
 


### PR DESCRIPTION
When working on OSX, a `.DS_Store` file gets automatically generated in directories opened in Finder. This breaks:
```
➜  DefinitelyTyped git:(master) ✗ npm test

> definitely-typed@0.0.1 test /Users/joscha/Development/DefinitelyTyped
> node node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed --nProcesses 1

Clean data
Clean logs
Clean output
# Typing Publish Report Summary
Started at Wed, 07 Jun 2017 22:23:34 GMT
Found 3160 typings folders in /Users/joscha/Development/DefinitelyTyped/types
Error: Package name `.DS_Store` should be strictly lowercase
    at Object.<anonymous> (/Users/joscha/Development/DefinitelyTyped/node_modules/types-publisher/src/lib/definition-parser.ts:17:9)
    at Generator.next (<anonymous>)
```