### PR TITLE
Change dependent types to be included as peerDependencies

### DIFF
--- a/src/lib/package-generator.ts
+++ b/src/lib/package-generator.ts
@@ -127,7 +127,7 @@ function addInferredDependencies(dependencies: Dependencies, peerDependencies: D
 		}
 
 		if (!handlesDependency(dependencies) && !handlesDependency(peerDependencies) && allPackages.hasTypingFor(dependency)) {
-			dependencies[typesDependency] = dependencySemver(dependency.majorVersion);
+			peerDependencies[typesDependency] = dependencySemver(dependency.majorVersion);
 		}
 	}
 }


### PR DESCRIPTION
Add all of the typesDependencies to be added as peerDependencies instead of dependencies to fix transitive dependency issues such as in https://github.com/Microsoft/types-publisher/issues/366

Tested locally and got expected results