### PR TITLE
Remove package.json field validation; done by dtslint

### DIFF
--- a/src/lib/package-generator.ts
+++ b/src/lib/package-generator.ts
@@ -75,11 +75,6 @@ export async function clearOutputPath(outputPath: string, log: Logger): Promise<
 
 interface Dependencies { [name: string]: string; }
 
-export interface PartialPackageJson {
-	dependencies?: Dependencies;
-	peerDependencies?: Dependencies;
-}
-
 async function createPackageJSON(typing: TypingsData, version: Semver, packages: AllPackages): Promise<string> {
 	// typing may provide a partial `package.json` for us to complete
 


### PR DESCRIPTION
`dtslint` includes its own `package.json` checker in `checks.ts`; `types-publisher` will still be responsible for checking `"dependencies"` though.
