### PR TITLE
When running on Azure, reset the contents of DefinitelyTyped

### DIFF
--- a/src/get-definitely-typed.ts
+++ b/src/get-definitely-typed.ts
@@ -21,6 +21,12 @@ export default async function main(options: Options): Promise<void> {
 			throw new Error(`Please checkout branch '${sourceBranch}`);
 		}
 
+		if (options.resetDefinitelyTyped) {
+			exec("git reset --hard origin/master", dtPath);
+			exec("git checkout -- .", dtPath);
+			exec("git clean -f -d", dtPath);
+		}
+
 		const diff = exec("git diff --name-only", dtPath);
 		if (diff) {
 			throw new Error(`'git diff' should be empty. Following files changed:\n${diff}`);

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -15,8 +15,8 @@ export const home = joinPaths(__dirname, "..", "..");
 /** Settings that may be determined dynamically. */
 export class Options {
 	/** Options for running locally. */
-	static defaults = new Options("../DefinitelyTyped", true);
-	static azure = new Options("../DefinitelyTyped", false);
+	static defaults = new Options("../DefinitelyTyped", /*resetDefinitelyTyped*/ false, /*progress*/ true);
+	static azure = new Options("../DefinitelyTyped", /*resetDefinitelyTyped*/ true, /*progress*/ false);
 
 	/** Location of all types packages. This is a subdirectory of DefinitelyTyped. */
 	readonly typesPath: string;
@@ -25,6 +25,7 @@ export class Options {
 		 * This is overridden to `cwd` when running the tester, as that is run from within DefinitelyTyped.
 		 */
 		readonly definitelyTypedPath: string,
+		readonly resetDefinitelyTyped: boolean,
 		/** Whether to show progress bars. Good when running locally, bad when running on travis / azure. */
 		readonly progress: boolean) {
 

--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -30,7 +30,7 @@ export function parseNProcesses(): number {
 
 export function testerOptions(runFromDefinitelyTyped: boolean): Options {
 	if (runFromDefinitelyTyped) {
-		return new Options(process.cwd(), false);
+		return new Options(process.cwd(), /*resetDefinitelyTyped*/ false, /*progress*/ false);
 	} else {
 		return Options.defaults;
 	}


### PR DESCRIPTION
This should help fix errors when the azure checkout gets into a bad state.