### PR TITLE
Add mqtt to dependeciesWhitelist.

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -9,6 +9,7 @@ immutable
 inversify
 localforage
 meteor-typings
+mqtt
 moment
 monaco-editor
 parse5


### PR DESCRIPTION
mqtt maintains its own types as of [2.5.0](https://github.com/mqttjs/MQTT.js/releases/tag/v2.5.0).

DefinitelyTyped/DefinitelyTyped#20343