### PR TITLE
Add redux-saga to whitelist dependencies

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -19,6 +19,7 @@ postcss
 protractor
 redux
 redux-persist
+redux-saga
 redux-thunk
 vue
 @types/vue


### PR DESCRIPTION
Module `redux-saga` provides its own types definitions which can be used to create definitions for extending modules.