### PR TITLE
Do not clear pathMappings if the path is defined for older version

### DIFF
--- a/src/check-parse-results.ts
+++ b/src/check-parse-results.ts
@@ -70,7 +70,9 @@ function checkPathMappings(allPackages: AllPackages): void {
 		}
 
 		for (const unusedPathMapping of unusedPathMappings) {
-			throw new Error(`${pkg.desc} has unused path mapping for ${unusedPathMapping}`);
+			if (pkg.name !== unusedPathMapping) {
+				throw new Error(`${pkg.desc} has unused path mapping for ${unusedPathMapping}`);
+			}
 		}
 	}
 }

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -251,9 +251,9 @@ async function calculateDependencies(packageName: string, tsconfig: TsConfig, de
 			if (dependencyNames.has(dependencyName)) {
 				dependencies[dependencyName] = version;
 			}
-			// Else, the path mapping may be necessary if it is for a dependency-of-a-dependency. We will check this in check-parse-results.
-			pathMappings[dependencyName] = version;
 		}
+		// Else, the path mapping may be necessary if it is for a dependency-of-a-dependency. We will check this in check-parse-results.
+		pathMappings[dependencyName] = version;
 	}
 
 	if (oldMajorVersion !== undefined && !(paths && packageName in paths)) {


### PR DESCRIPTION
… of the package

This patch resolves problem with https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20443 (https://github.com/dex4er/DefinitelyTyped/tree/nodemailer)

nodemailer/v3 depends on nodemailer-direct-transport which depends on nodemailer/v3.

Unfortunately, I've got the error:

```
Error: nodemailer v3 depends on nodemailer-direct-transport, which has a path mapping for nodemailer v3. nodemailer v3 must have the same path mappings as its dependencies.
```

It is because types-publisher clears pathMappings for older version of nodemailer package. So pathMappings is not the same for nodemailer/v3 and nodemailer-direct-transport.

This patch doesn't clear if the package name is the same as some unused path mapping. It should be a correct situation.
