### PR TITLE
Add: "flatpickr" module to dependency whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -5,6 +5,7 @@ axios
 electron
 eventemitter2
 eventemitter3
+flatpickr
 immutable
 inversify
 localforage


### PR DESCRIPTION
`flatpickr` module now provides its own types and will be needed by the `react-flatpickr` definition file (in the DefinitelyTyped repo).