### PR TITLE
Clean `output` directory once, instead of redoing it for each generated package

### DIFF
--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -1,8 +1,9 @@
+import { emptyDir } from "fs-extra";
 import * as yargs from "yargs";
 
 import { Options } from "./lib/common";
 import generateAnyPackage from "./lib/package-generator";
-import { AllPackages } from "./lib/packages";
+import { AllPackages, outputDir } from "./lib/packages";
 import Versions, { changedPackages } from "./lib/versions";
 import { logger, moveLogs, writeLog } from "./util/logging";
 import { writeTgz } from "./util/tgz";
@@ -23,6 +24,8 @@ export default async function main(options: Options, all = false, tgz = false): 
 	log(`\n## Generating ${all ? "all" : "changed"} packages\n`);
 	const allPackages = await AllPackages.read(options);
 	const versions = await Versions.load();
+
+	await emptyDir(outputDir);
 
 	const packages = all ? allPackages.allPackages() : await changedPackages(allPackages);
 

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -201,7 +201,7 @@ export function fullNpmName(packageName: string): string {
 	return `@${scopeName}/${packageName}`;
 }
 
-const outputDir = joinPaths(home, outputPath);
+export const outputDir = joinPaths(home, outputPath);
 
 interface NotNeededPackageRaw extends BaseRaw {
 	/**

--- a/src/publish-registry.ts
+++ b/src/publish-registry.ts
@@ -1,14 +1,13 @@
 import assert = require("assert");
-import { emptyDir } from "fs-extra";
+import { emptyDir, mkdir } from "fs-extra";
 import * as yargs from "yargs";
 
 import NpmClient from "./lib/npm-client";
-import { clearOutputPath } from "./lib/package-generator";
 import { AllPackages, TypingsData } from "./lib/packages";
 import { outputPath, validateOutputPath } from "./lib/settings";
 import { fetchNpmInfo } from "./lib/versions";
 import { assertDirectoriesEqual, npmInstallFlags, writeFile, writeJson } from "./util/io";
-import { Logger, logger, writeLog } from "./util/logging";
+import { logger, writeLog } from "./util/logging";
 import { computeHash, done, execAndThrowErrors, joinPaths } from "./util/util";
 
 const packageName = "types-registry";
@@ -37,7 +36,7 @@ export default async function main(dry: boolean): Promise<void> {
 	assert.equal(oldVersion.minor, 1);
 	const newVersion = `0.1.${oldVersion.patch + 1}`;
 	const packageJson = generatePackageJson(newVersion, newContentHash);
-	await generate(registry, packageJson, log);
+	await generate(registry, packageJson);
 
 	if (oldContentHash !== newContentHash) {
 		log("New packages have been added, so publishing a new registry.");
@@ -51,8 +50,8 @@ export default async function main(dry: boolean): Promise<void> {
 	await writeLog("publish-registry.md", logResult());
 }
 
-async function generate(registry: string, packageJson: {}, log: Logger): Promise<void> {
-	await clearOutputPath(registryOutputPath, log);
+async function generate(registry: string, packageJson: {}): Promise<void> {
+	await mkdir(registryOutputPath);
 	await writeOutputJson("package.json", packageJson);
 	await writeOutputFile("index.json", registry);
 	await writeOutputFile("README.md", readme);


### PR DESCRIPTION
On azure we're getting an `Error: EPERM: operation not permitted, open 'D:\home\site\wwwroot\output\nodemailer\index.d.ts'`. This may be due to some unnecessary parallelism in the I/O operations we do to output.