### PR TITLE
Dedupe files entries for index.d.ts

### DIFF
--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -42,6 +42,7 @@ export default async function main(options: Options, all = false, tgz = false): 
 }
 
 async function single(singleName: string, options: Options): Promise<void> {
+	await emptyDir(outputDir);
 	const allPackages = await AllPackages.read(options);
 	const pkg = allPackages.getSingle(singleName);
 	const versions = await Versions.load();


### PR DESCRIPTION
We were getting an error on Azure: `Error: EPERM: operation not permitted, open 'D:\home\site\wwwroot\output\nodemailer\index.d.ts`. (#394 didn't solve it.)
This was because in `nodemailer`, `index.d.ts` is referenced from a file in a child directory. This caused us to add a file entry for `./index.d.ts`, but there was already one for `index.d.ts`.
Normally this is not a big deal. But since we do our I/O in parallel, during package generation we would try copying `./index.d.ts` and `index.d.ts` at the same time. On Windows this results in `EPERM` for some reason.