### PR TITLE
For dependent packages, only test against typescript@next

### DIFF
--- a/src/check-parse-results.ts
+++ b/src/check-parse-results.ts
@@ -14,6 +14,8 @@ export default async function main(includeNpmChecks: boolean, options: Options):
 	const allPackages = await AllPackages.read(options);
 	const [log, logResult] = logger();
 
+	checkTypeScriptVersions(allPackages);
+
 	checkPathMappings(allPackages);
 
 	const packages = allPackages.allPackages();
@@ -45,6 +47,16 @@ function checkForDuplicates(packages: ReadonlyArray<AnyPackage>, func: (info: An
 			log(` * Duplicate ${key} descriptions "${libName}"`);
 			for (const n of values) {
 				log(`   * ${n.desc}`);
+			}
+		}
+	}
+}
+
+function checkTypeScriptVersions(allPackages: AllPackages): void {
+	for (const pkg of allPackages.allTypings()) {
+		for (const dep of allPackages.allDependencyTypings(pkg)) {
+			if (dep.typeScriptVersion > pkg.typeScriptVersion) {
+				throw new Error(`${pkg.desc} depends on ${dep.desc} but has a lower required TypeScript version.`);
 			}
 		}
 	}

--- a/src/lib/module-info.ts
+++ b/src/lib/module-info.ts
@@ -380,7 +380,7 @@ export async function getTestDependencies(pkgName: string, directory: string, te
 		}
 
 		for (const imported of imports(sourceFile)) {
-			if (!imported.startsWith(".") && !dependencies.has(imported)) {
+			if (!imported.startsWith(".") && !dependencies.has(imported) && imported !== pkgName) {
 				testDependencies.add(imported);
 			}
 		}

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -202,6 +202,11 @@ export function multiMapAdd<K, V>(map: Map<K, V[]>, key: K, value: V): void {
 	}
 }
 
+export function* concat<T>(a: Iterable<T>, b: Iterable<T>): Iterable<T> {
+	yield* a;
+	yield* b;
+}
+
 export function mapDefined<T, U>(arr: Iterable<T>, mapper: (t: T) => U | undefined): U[] {
 	const out = [];
 	for (const a of arr) {


### PR DESCRIPTION
Normally we test against both `typescript@next` and the minimum available TypeScript version. This would change it so that for dependencies, we would only test against `typescript@next`. This should help with DefinitelyTyped/DefinitelyTyped#20308.
This means adding a `--onlyTestTsNext` option to dtslint: Microsoft/dtslint#87.
To avoid this causing problems when a package changes the TS version it depends on, this adds a new rule that if A depends on B, A must have a greater TS version than B. This is done by DefinitelyTyped/DefinitelyTyped#21288.