### PR TITLE
Add mongodb to dependency whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -15,6 +15,7 @@ meteor-typings
 mqtt
 moment
 monaco-editor
+mongodb
 parse5
 path-to-regexp
 pkcs11js


### PR DESCRIPTION
@types/mongoose require @types/mongodb@2.1.43 or later so we need to add to this whitelist.

This issue: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/17128
suggests that `@types/mongoose` requires `@types/monogodb@2.1.43` or higher because we require an interface called `Decimal128`.

The Travis build failed telling me to submit a PR here. Please advise. 
https://travis-ci.org/DefinitelyTyped/DefinitelyTyped/builds/301786654?utm_source=github_status&utm_medium=notification

Thank you!