### PR TITLE
Remove modules with ambient declarations from parsed dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "upload-blobs": "node bin/upload-blobs.js",
     "full": "node bin/full.js",
     "full-dry": "node bin/full.js --dry",
-    "lint": "node node_modules/tslint/bin/tslint --format stylish --project tsconfig.json --type-check",
+    "lint": "node node_modules/tslint/bin/tslint --format stylish --project tsconfig.json",
     "webhook-dry": "node ./bin/webhook.js --dry",
     "make-server-run": "node bin/make-server-run.js",
     "make-production-server-run": "node bin/make-server-run.js --remote",

--- a/src/lib/module-info.ts
+++ b/src/lib/module-info.ts
@@ -355,8 +355,13 @@ function noWindowsSlashes(packageName: string, fileName: string): void {
 	}
 }
 
-export async function getTestDependencies(pkgName: string, directory: string, testFiles: string[], dependencies: Set<string>): Promise<string[]> {
-	const testDependencies = new Set();
+export async function getTestDependencies(
+	pkgName: string,
+	directory: string,
+	testFiles: string[],
+	dependencies: ReadonlySet<string>,
+): Promise<Iterable<string>> {
+	const testDependencies = new Set<string>();
 
 	for (const filename of testFiles) {
 		const content = await readFileAndThrowOnBOM(directory, filename);
@@ -386,7 +391,7 @@ export async function getTestDependencies(pkgName: string, directory: string, te
 		}
 	}
 
-	return Array.from(testDependencies);
+	return testDependencies;
 }
 
 function createSourceFile(filename: string, content: string): ts.SourceFile {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -70,6 +70,21 @@ export async function nAtATime<T, U>(
 	return results;
 }
 
+export function filter<T>(iterable: Iterable<T>, predicate: (value: T) => boolean): IterableIterator<T> {
+	const iter = iterable[Symbol.iterator]();
+	return {
+		[Symbol.iterator](): IterableIterator<T> { return this; },
+		next(): IteratorResult<T> {
+			while (true) {
+				const res = iter.next();
+				if (res.done || predicate(res.value)) {
+					return res;
+				}
+			}
+		}
+	};
+}
+
 export async function filterNAtATime<T>(
 	n: number, inputs: ReadonlyArray<T>, shouldKeep: (input: T) => Promise<boolean>, progress?: ProgressOptions<T, boolean>): Promise<T[]> {
 	const shouldKeeps: boolean[] = await nAtATime(n, inputs, shouldKeep, progress);


### PR DESCRIPTION
Fixes DefinitelyTyped/DefinitelyTyped#21941
The import of "events" was not for `@types/events` but for the local `declare module "events"`, so the dependency is unnecessary.