### PR TITLE
Clean up `getModuleInfo` and apply stricter linting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.58"
       }
     },
     "@types/fs-extra": {
@@ -19,7 +19,7 @@
       "integrity": "sha512-PlKJw6ujJXLJjbvB3T0UCbY3jibKM6/Ya5cc9j1q+mYDeK3aR4Dp+20ZwxSuvJr9mIoPxp7+IL4aMOEvsscRTA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.58"
       }
     },
     "@types/mz": {
@@ -28,13 +28,13 @@
       "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.58"
       }
     },
     "@types/node": {
-      "version": "8.0.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.53.tgz",
-      "integrity": "sha512-54Dm6NwYeiSQmRB1BLXKr5GELi0wFapR1npi8bnZhEcu84d/yQKqnwwXQ56hZ0RUbTG6L5nqDZaN3dgByQXQRQ=="
+      "version": "8.0.58",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.58.tgz",
+      "integrity": "sha512-V746iUU7eHNdzQipoACuguDlVhC7IHK8CES1jSkuFt352wwA84BCWPXaGekBd7R5XdNK5ReHONDVKxlL9IreAw=="
     },
     "@types/node-fetch": {
       "version": "1.6.7",
@@ -42,7 +42,7 @@
       "integrity": "sha1-UhB46PDGmhWOUCIAWsqS0mIPbVc=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.58"
       }
     },
     "@types/oboe": {
@@ -51,13 +51,13 @@
       "integrity": "sha1-OvywzJSfzfd3hh2W6FcfO0hvD6c=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.58"
       }
     },
     "@types/parsimmon": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.3.1.tgz",
-      "integrity": "sha512-xSPnj6R/h8ksvfaFwkhfxnSPhd0eRD1LwfB59L3GJuMUe4zjXGUSb3YZ5eUSM8jk4/qH72FtKzOYtLnZh/OgKQ=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.6.1.tgz",
+      "integrity": "sha512-JdPkIcXDnNiDD6k2FKrB12YWQ5Bcq3hX2DovpU+IGg8yg/aKCTT5xKJVKRXbts1GGXi5P8T8KpCJT98WWjCyGw=="
     },
     "@types/semver": {
       "version": "5.4.0",
@@ -71,7 +71,7 @@
       "integrity": "sha512-9oVAi1Jlr274pbMGPEe0S3IPImV9knVNafa6E4MookD/fjOZAE6EmLkFX5ZjtZ9OXNPi2FCIZzUSMvwAUUKeSg==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.58"
       }
     },
     "@types/tar": {
@@ -80,21 +80,21 @@
       "integrity": "sha1-qvBknYO6pE9Ji/ezVP0ECtjIubM=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "8.0.58"
       }
     },
     "@types/yargs": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.3.tgz",
+      "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w==",
       "dev": true
     },
     "adal-node": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.25.tgz",
-      "integrity": "sha1-ZVQ1CrQpFIcABMRcDWREjz2/zQM=",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.26.tgz",
+      "integrity": "sha1-WgqVW3Tujyu0TzIwXK/cemh3/O0=",
       "requires": {
-        "@types/node": "8.0.53",
+        "@types/node": "8.0.58",
         "async": "2.6.0",
         "date-utils": "1.2.21",
         "jws": "3.1.4",
@@ -106,9 +106,9 @@
       }
     },
     "ajv": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.0.tgz",
-      "integrity": "sha1-6yhAdG6dxIvV4GOjbj/UAMXqtak=",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
@@ -200,9 +200,9 @@
       }
     },
     "azure-storage": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.6.0.tgz",
-      "integrity": "sha1-hHR+5UpL0ZS7lg+J8+/4nWes8c8=",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.7.0.tgz",
+      "integrity": "sha1-EGw18LpsVR+Si9OUwCbkTQQB/88=",
       "requires": {
         "browserify-mime": "1.2.9",
         "extend": "1.2.1",
@@ -619,7 +619,7 @@
     "definitelytyped-header-parser": {
       "version": "github:Microsoft/definitelytyped-header-parser#210b44cf9e7e5b9783a41df4f664695ade5325b1",
       "requires": {
-        "@types/parsimmon": "1.3.1",
+        "@types/parsimmon": "1.6.1",
         "parsimmon": "1.6.2"
       }
     },
@@ -646,7 +646,7 @@
         "fs-promise": "2.0.3",
         "strip-json-comments": "2.0.1",
         "tslint": "5.8.0",
-        "typescript": "2.7.0-dev.20171208"
+        "typescript": "2.7.0-dev.20171212"
       }
     },
     "duplexer": {
@@ -888,7 +888,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.0",
+        "ajv": "5.5.1",
         "har-schema": "2.0.0"
       }
     },
@@ -1246,9 +1246,9 @@
       }
     },
     "moment": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
-      "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8="
+      "version": "2.19.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.4.tgz",
+      "integrity": "sha512-1xFTAknSLfc47DIxHDUbnJWC+UwgWxATmymaxIPQpmMh7LBm7ZbwVEsuushqwL2GYZU0jie4xO+TK44hJPjNSQ=="
     },
     "ms-rest": {
       "version": "1.15.7",
@@ -1256,7 +1256,7 @@
       "integrity": "sha1-QAUV4FsZJIicthoexgVCkKaOEgc=",
       "requires": {
         "duplexer": "0.1.1",
-        "moment": "2.19.3",
+        "moment": "2.19.4",
         "request": "2.74.0",
         "through": "2.3.8",
         "tunnel": "0.0.5",
@@ -1399,10 +1399,10 @@
       "resolved": "https://registry.npmjs.org/ms-rest-azure/-/ms-rest-azure-1.15.7.tgz",
       "integrity": "sha1-i84J8FOxVl26qL0CLKQBVcNbD94=",
       "requires": {
-        "adal-node": "0.1.25",
+        "adal-node": "0.1.26",
         "async": "0.2.7",
         "azure-arm-resource": "1.6.1-preview",
-        "moment": "2.19.3",
+        "moment": "2.19.4",
         "ms-rest": "1.15.7",
         "uuid": "3.1.0"
       },
@@ -1445,9 +1445,9 @@
       }
     },
     "npm": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-5.5.1.tgz",
-      "integrity": "sha512-M3aO8EjHebaCw6uur4C86SZqkypnoaEVo5R63FEEU0dw9wLxf/JlwWtJItShYVyQS2WDxG2It10GEe5GmVEM2Q==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-5.6.0.tgz",
+      "integrity": "sha512-mt839mCsI5hzdBJLf1iRBwt610P35iUfvqLVuL7VFdanUwRBAmGtbsjdGIuzegplR95xx+fTHE0vBMuMJp1sLQ==",
       "requires": {
         "JSONStream": "1.3.1",
         "abbrev": "1.1.1",
@@ -1456,8 +1456,9 @@
         "ansistyles": "0.1.3",
         "aproba": "1.2.0",
         "archy": "1.0.0",
-        "bluebird": "3.5.0",
-        "cacache": "9.2.9",
+        "bin-links": "1.1.0",
+        "bluebird": "3.5.1",
+        "cacache": "10.0.1",
         "call-limit": "1.1.0",
         "chownr": "1.0.1",
         "cli-table2": "0.2.0",
@@ -1468,8 +1469,10 @@
         "detect-indent": "5.0.0",
         "dezalgo": "1.0.3",
         "editor": "1.0.0",
+        "find-npm-prefix": "1.0.1",
         "fs-vacuum": "1.2.10",
         "fs-write-stream-atomic": "1.0.10",
+        "gentle-fs": "2.0.1",
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
         "has-unicode": "2.0.1",
@@ -1482,7 +1485,7 @@
         "init-package-json": "1.10.1",
         "is-cidr": "1.0.0",
         "lazy-property": "1.0.0",
-        "libnpx": "9.6.0",
+        "libnpx": "9.7.1",
         "lockfile": "1.0.3",
         "lodash._baseindexof": "3.1.0",
         "lodash._baseuniq": "4.6.0",
@@ -1500,26 +1503,25 @@
         "mississippi": "1.3.0",
         "mkdirp": "0.5.1",
         "move-concurrently": "1.0.1",
-        "node-gyp": "3.6.2",
         "nopt": "4.0.1",
         "normalize-package-data": "2.4.0",
         "npm-cache-filename": "1.0.2",
         "npm-install-checks": "3.0.0",
-        "npm-lifecycle": "1.0.3",
-        "npm-package-arg": "5.1.2",
-        "npm-packlist": "1.1.9",
-        "npm-profile": "2.0.4",
+        "npm-lifecycle": "2.0.0",
+        "npm-package-arg": "6.0.0",
+        "npm-packlist": "1.1.10",
+        "npm-profile": "2.0.5",
         "npm-registry-client": "8.5.0",
         "npm-user-validate": "1.0.0",
         "npmlog": "4.1.2",
         "once": "1.4.0",
         "opener": "1.4.3",
         "osenv": "0.1.4",
-        "pacote": "6.0.2",
+        "pacote": "7.0.2",
         "path-is-inside": "1.0.2",
         "promise-inflight": "1.0.1",
         "qrcode-terminal": "0.11.0",
-        "query-string": "5.0.0",
+        "query-string": "5.0.1",
         "qw": "1.0.1",
         "read": "1.0.7",
         "read-cmd-shim": "1.0.1",
@@ -1537,20 +1539,20 @@
         "slide": "1.1.6",
         "sorted-object": "2.0.1",
         "sorted-union-stream": "2.1.3",
-        "ssri": "4.1.6",
+        "ssri": "5.0.0",
         "strip-ansi": "4.0.0",
-        "tar": "4.0.1",
+        "tar": "4.0.2",
         "text-table": "0.2.0",
         "uid-number": "0.0.6",
         "umask": "1.1.0",
         "unique-filename": "1.1.0",
         "unpipe": "1.0.0",
-        "update-notifier": "2.2.0",
+        "update-notifier": "2.3.0",
         "uuid": "3.1.0",
         "validate-npm-package-license": "3.0.1",
         "validate-npm-package-name": "3.0.0",
         "which": "1.3.0",
-        "worker-farm": "1.5.0",
+        "worker-farm": "1.5.1",
         "wrappy": "1.0.2",
         "write-file-atomic": "2.1.0"
       },
@@ -1597,15 +1599,27 @@
           "version": "1.0.0",
           "bundled": true
         },
+        "bin-links": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "cmd-shim": "2.0.2",
+            "fs-write-stream-atomic": "1.0.10",
+            "gentle-fs": "2.0.1",
+            "graceful-fs": "4.1.11",
+            "slide": "1.1.6"
+          }
+        },
         "bluebird": {
-          "version": "3.5.0",
+          "version": "3.5.1",
           "bundled": true
         },
         "cacache": {
-          "version": "9.2.9",
+          "version": "10.0.1",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.0",
+            "bluebird": "3.5.1",
             "chownr": "1.0.1",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
@@ -1615,27 +1629,16 @@
             "move-concurrently": "1.0.1",
             "promise-inflight": "1.0.1",
             "rimraf": "2.6.2",
-            "ssri": "4.1.6",
+            "ssri": "5.0.0",
             "unique-filename": "1.1.0",
             "y18n": "3.2.1"
           },
           "dependencies": {
-            "lru-cache": {
-              "version": "4.1.1",
+            "ssri": {
+              "version": "5.0.0",
               "bundled": true,
               "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
-              },
-              "dependencies": {
-                "pseudomap": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "yallist": {
-                  "version": "2.1.2",
-                  "bundled": true
-                }
+                "safe-buffer": "5.1.1"
               }
             },
             "y18n": {
@@ -1806,6 +1809,10 @@
           "version": "1.0.0",
           "bundled": true
         },
+        "find-npm-prefix": {
+          "version": "1.0.1",
+          "bundled": true
+        },
         "fs-vacuum": {
           "version": "1.2.10",
           "bundled": true,
@@ -1823,6 +1830,20 @@
             "iferr": "0.1.5",
             "imurmurhash": "0.1.4",
             "readable-stream": "2.3.3"
+          }
+        },
+        "gentle-fs": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "fs-vacuum": "1.2.10",
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "path-is-inside": "1.0.2",
+            "read-cmd-shim": "1.0.1",
+            "slide": "1.1.6"
           }
         },
         "glob": {
@@ -1924,6 +1945,16 @@
             "validate-npm-package-name": "3.0.0"
           },
           "dependencies": {
+            "npm-package-arg": {
+              "version": "5.1.2",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.5.0",
+                "osenv": "0.1.4",
+                "semver": "5.4.1",
+                "validate-npm-package-name": "3.0.0"
+              }
+            },
             "promzard": {
               "version": "0.3.0",
               "bundled": true,
@@ -1951,14 +1982,14 @@
           "bundled": true
         },
         "libnpx": {
-          "version": "9.6.0",
+          "version": "9.7.1",
           "bundled": true,
           "requires": {
             "dotenv": "4.0.0",
             "npm-package-arg": "5.1.2",
             "rimraf": "2.6.2",
             "safe-buffer": "5.1.1",
-            "update-notifier": "2.2.0",
+            "update-notifier": "2.3.0",
             "which": "1.3.0",
             "y18n": "3.2.1",
             "yargs": "8.0.2"
@@ -1967,6 +1998,16 @@
             "dotenv": {
               "version": "4.0.0",
               "bundled": true
+            },
+            "npm-package-arg": {
+              "version": "5.1.2",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.5.0",
+                "osenv": "0.1.4",
+                "semver": "5.4.1",
+                "validate-npm-package-name": "3.0.0"
+              }
             },
             "y18n": {
               "version": "3.2.1",
@@ -2578,7 +2619,7 @@
           "bundled": true,
           "requires": {
             "aproba": "1.2.0",
-            "copy-concurrently": "1.0.3",
+            "copy-concurrently": "1.0.5",
             "fs-write-stream-atomic": "1.0.10",
             "mkdirp": "0.5.1",
             "rimraf": "2.6.2",
@@ -2586,7 +2627,7 @@
           },
           "dependencies": {
             "copy-concurrently": {
-              "version": "1.0.3",
+              "version": "1.0.5",
               "bundled": true,
               "requires": {
                 "aproba": "1.2.0",
@@ -2738,18 +2779,31 @@
           }
         },
         "npm-lifecycle": {
-          "version": "1.0.3",
+          "version": "2.0.0",
           "bundled": true,
           "requires": {
+            "byline": "5.0.0",
             "graceful-fs": "4.1.11",
+            "node-gyp": "3.6.2",
+            "resolve-from": "4.0.0",
             "slide": "1.1.6",
             "uid-number": "0.0.6",
             "umask": "1.1.0",
             "which": "1.3.0"
+          },
+          "dependencies": {
+            "byline": {
+              "version": "5.0.0",
+              "bundled": true
+            },
+            "resolve-from": {
+              "version": "4.0.0",
+              "bundled": true
+            }
           }
         },
         "npm-package-arg": {
-          "version": "5.1.2",
+          "version": "6.0.0",
           "bundled": true,
           "requires": {
             "hosted-git-info": "2.5.0",
@@ -2759,15 +2813,15 @@
           }
         },
         "npm-packlist": {
-          "version": "1.1.9",
+          "version": "1.1.10",
           "bundled": true,
           "requires": {
-            "ignore-walk": "3.0.0",
+            "ignore-walk": "3.0.1",
             "npm-bundled": "1.0.3"
           },
           "dependencies": {
             "ignore-walk": {
-              "version": "3.0.0",
+              "version": "3.0.1",
               "bundled": true,
               "requires": {
                 "minimatch": "3.0.4"
@@ -2809,7 +2863,7 @@
           }
         },
         "npm-profile": {
-          "version": "2.0.4",
+          "version": "2.0.5",
           "bundled": true,
           "requires": {
             "aproba": "1.2.0",
@@ -2821,8 +2875,8 @@
               "bundled": true,
               "requires": {
                 "agentkeepalive": "3.3.0",
-                "cacache": "9.2.9",
-                "http-cache-semantics": "3.7.3",
+                "cacache": "9.3.0",
+                "http-cache-semantics": "3.8.0",
                 "http-proxy-agent": "2.0.0",
                 "https-proxy-agent": "2.1.0",
                 "lru-cache": "4.1.1",
@@ -2855,8 +2909,33 @@
                     }
                   }
                 },
+                "cacache": {
+                  "version": "9.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "bluebird": "3.5.1",
+                    "chownr": "1.0.1",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "lru-cache": "4.1.1",
+                    "mississippi": "1.3.0",
+                    "mkdirp": "0.5.1",
+                    "move-concurrently": "1.0.1",
+                    "promise-inflight": "1.0.1",
+                    "rimraf": "2.6.2",
+                    "ssri": "4.1.6",
+                    "unique-filename": "1.1.0",
+                    "y18n": "3.2.1"
+                  },
+                  "dependencies": {
+                    "y18n": {
+                      "version": "3.2.1",
+                      "bundled": true
+                    }
+                  }
+                },
                 "http-cache-semantics": {
-                  "version": "3.7.3",
+                  "version": "3.8.0",
                   "bundled": true
                 },
                 "http-proxy-agent": {
@@ -3040,6 +3119,13 @@
                       }
                     }
                   }
+                },
+                "ssri": {
+                  "version": "4.1.6",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.1"
+                  }
                 }
               }
             }
@@ -3075,6 +3161,23 @@
                   "version": "0.0.6",
                   "bundled": true
                 }
+              }
+            },
+            "npm-package-arg": {
+              "version": "5.1.2",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.5.0",
+                "osenv": "0.1.4",
+                "semver": "5.4.1",
+                "validate-npm-package-name": "3.0.0"
+              }
+            },
+            "ssri": {
+              "version": "4.1.6",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
               }
             }
           }
@@ -3219,47 +3322,52 @@
           }
         },
         "pacote": {
-          "version": "6.0.2",
+          "version": "7.0.2",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.0",
-            "cacache": "9.2.9",
+            "bluebird": "3.5.1",
+            "cacache": "10.0.1",
+            "get-stream": "3.0.0",
             "glob": "7.1.2",
             "lru-cache": "4.1.1",
-            "make-fetch-happen": "2.5.0",
+            "make-fetch-happen": "2.6.0",
             "minimatch": "3.0.4",
             "mississippi": "1.3.0",
             "normalize-package-data": "2.4.0",
-            "npm-package-arg": "5.1.2",
-            "npm-packlist": "1.1.9",
-            "npm-pick-manifest": "1.0.4",
+            "npm-package-arg": "6.0.0",
+            "npm-packlist": "1.1.10",
+            "npm-pick-manifest": "2.1.0",
             "osenv": "0.1.4",
             "promise-inflight": "1.0.1",
             "promise-retry": "1.1.1",
             "protoduck": "4.0.0",
             "safe-buffer": "5.1.1",
             "semver": "5.4.1",
-            "ssri": "4.1.6",
-            "tar": "4.0.1",
+            "ssri": "5.0.0",
+            "tar": "4.0.2",
             "unique-filename": "1.1.0",
             "which": "1.3.0"
           },
           "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
             "make-fetch-happen": {
-              "version": "2.5.0",
+              "version": "2.6.0",
               "bundled": true,
               "requires": {
                 "agentkeepalive": "3.3.0",
-                "cacache": "9.2.9",
-                "http-cache-semantics": "3.7.3",
+                "cacache": "10.0.1",
+                "http-cache-semantics": "3.8.0",
                 "http-proxy-agent": "2.0.0",
                 "https-proxy-agent": "2.1.0",
                 "lru-cache": "4.1.1",
                 "mississippi": "1.3.0",
                 "node-fetch-npm": "2.0.2",
                 "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.0",
-                "ssri": "4.1.6"
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.0.0"
               },
               "dependencies": {
                 "agentkeepalive": {
@@ -3285,19 +3393,19 @@
                   }
                 },
                 "http-cache-semantics": {
-                  "version": "3.7.3",
+                  "version": "3.8.0",
                   "bundled": true
                 },
                 "http-proxy-agent": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.1.1",
-                    "debug": "2.6.8"
+                    "agent-base": "4.1.2",
+                    "debug": "2.6.9"
                   },
                   "dependencies": {
                     "agent-base": {
-                      "version": "4.1.1",
+                      "version": "4.1.2",
                       "bundled": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -3319,7 +3427,7 @@
                       }
                     },
                     "debug": {
-                      "version": "2.6.8",
+                      "version": "2.6.9",
                       "bundled": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -3337,12 +3445,12 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.1.1",
-                    "debug": "2.6.8"
+                    "agent-base": "4.1.2",
+                    "debug": "2.6.9"
                   },
                   "dependencies": {
                     "agent-base": {
-                      "version": "4.1.1",
+                      "version": "4.1.2",
                       "bundled": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -3364,7 +3472,7 @@
                       }
                     },
                     "debug": {
-                      "version": "2.6.8",
+                      "version": "2.6.9",
                       "bundled": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -3391,11 +3499,11 @@
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "0.4.18"
+                        "iconv-lite": "0.4.19"
                       },
                       "dependencies": {
                         "iconv-lite": {
-                          "version": "0.4.18",
+                          "version": "0.4.19",
                           "bundled": true
                         }
                       }
@@ -3407,15 +3515,15 @@
                   }
                 },
                 "socks-proxy-agent": {
-                  "version": "3.0.0",
+                  "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.1.1",
+                    "agent-base": "4.1.2",
                     "socks": "1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
-                      "version": "4.1.1",
+                      "version": "4.1.2",
                       "bundled": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -3486,10 +3594,10 @@
               }
             },
             "npm-pick-manifest": {
-              "version": "1.0.4",
+              "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "npm-package-arg": "5.1.2",
+                "npm-package-arg": "6.0.0",
                 "semver": "5.4.1"
               }
             },
@@ -3535,7 +3643,7 @@
           "bundled": true
         },
         "query-string": {
-          "version": "5.0.0",
+          "version": "5.0.1",
           "bundled": true,
           "requires": {
             "decode-uri-component": "0.2.0",
@@ -4120,7 +4228,7 @@
           }
         },
         "ssri": {
-          "version": "4.1.6",
+          "version": "5.0.0",
           "bundled": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -4140,12 +4248,12 @@
           }
         },
         "tar": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "requires": {
             "chownr": "1.0.1",
             "minipass": "2.2.1",
-            "minizlib": "1.0.3",
+            "minizlib": "1.0.4",
             "mkdirp": "0.5.1",
             "yallist": "3.0.2"
           },
@@ -4158,7 +4266,7 @@
               }
             },
             "minizlib": {
-              "version": "1.0.3",
+              "version": "1.0.4",
               "bundled": true,
               "requires": {
                 "minipass": "2.2.1"
@@ -4203,13 +4311,14 @@
           "bundled": true
         },
         "update-notifier": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "boxen": "1.1.0",
-            "chalk": "1.1.3",
-            "configstore": "3.1.0",
+            "boxen": "1.2.1",
+            "chalk": "2.1.0",
+            "configstore": "3.1.1",
             "import-lazy": "2.1.0",
+            "is-installed-globally": "0.1.0",
             "is-npm": "1.0.0",
             "latest-version": "3.1.0",
             "semver-diff": "2.1.0",
@@ -4217,15 +4326,15 @@
           },
           "dependencies": {
             "boxen": {
-              "version": "1.1.0",
+              "version": "1.2.1",
               "bundled": true,
               "requires": {
                 "ansi-align": "2.0.0",
                 "camelcase": "4.1.0",
-                "chalk": "1.1.3",
+                "chalk": "2.1.0",
                 "cli-boxes": "1.0.0",
-                "string-width": "2.1.0",
-                "term-size": "0.1.1",
+                "string-width": "2.1.1",
+                "term-size": "1.2.0",
                 "widest-line": "1.0.0"
               },
               "dependencies": {
@@ -4233,7 +4342,7 @@
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "2.1.0"
+                    "string-width": "2.1.1"
                   }
                 },
                 "camelcase": {
@@ -4245,7 +4354,7 @@
                   "bundled": true
                 },
                 "string-width": {
-                  "version": "2.1.0",
+                  "version": "2.1.1",
                   "bundled": true,
                   "requires": {
                     "is-fullwidth-code-point": "2.0.0",
@@ -4255,60 +4364,80 @@
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
                       "bundled": true
-                    },
-                    "strip-ansi": {
-                      "version": "4.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "ansi-regex": "3.0.0"
-                      }
                     }
                   }
                 },
                 "term-size": {
-                  "version": "0.1.1",
+                  "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "execa": "0.4.0"
+                    "execa": "0.7.0"
                   },
                   "dependencies": {
                     "execa": {
-                      "version": "0.4.0",
+                      "version": "0.7.0",
                       "bundled": true,
                       "requires": {
-                        "cross-spawn-async": "2.2.5",
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
                         "is-stream": "1.1.0",
-                        "npm-run-path": "1.0.0",
-                        "object-assign": "4.1.1",
-                        "path-key": "1.0.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
                         "strip-eof": "1.0.0"
                       },
                       "dependencies": {
-                        "cross-spawn-async": {
-                          "version": "2.2.5",
+                        "cross-spawn": {
+                          "version": "5.1.0",
                           "bundled": true,
                           "requires": {
                             "lru-cache": "4.1.1",
+                            "shebang-command": "1.2.0",
                             "which": "1.3.0"
+                          },
+                          "dependencies": {
+                            "shebang-command": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "shebang-regex": "1.0.0"
+                              },
+                              "dependencies": {
+                                "shebang-regex": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
                           }
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
                         },
                         "is-stream": {
                           "version": "1.1.0",
                           "bundled": true
                         },
                         "npm-run-path": {
-                          "version": "1.0.0",
+                          "version": "2.0.2",
                           "bundled": true,
                           "requires": {
-                            "path-key": "1.0.0"
+                            "path-key": "2.0.1"
+                          },
+                          "dependencies": {
+                            "path-key": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
                           }
                         },
-                        "object-assign": {
-                          "version": "4.1.1",
+                        "p-finally": {
+                          "version": "1.0.0",
                           "bundled": true
                         },
-                        "path-key": {
-                          "version": "1.0.0",
+                        "signal-exit": {
+                          "version": "3.0.2",
                           "bundled": true
                         },
                         "strip-eof": {
@@ -4372,61 +4501,60 @@
               }
             },
             "chalk": {
-              "version": "1.1.3",
+              "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "ansi-styles": "2.2.1",
+                "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "supports-color": "4.4.0"
               },
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.2.1",
-                  "bundled": true
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  },
+                  "dependencies": {
+                    "color-convert": {
+                      "version": "1.9.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-name": "1.1.3"
+                      },
+                      "dependencies": {
+                        "color-name": {
+                          "version": "1.1.3",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
                   "bundled": true
                 },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                },
                 "supports-color": {
-                  "version": "2.0.0",
-                  "bundled": true
+                  "version": "4.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "2.0.0"
+                  },
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    }
+                  }
                 }
               }
             },
             "configstore": {
-              "version": "3.1.0",
+              "version": "3.1.1",
               "bundled": true,
               "requires": {
-                "dot-prop": "4.1.1",
+                "dot-prop": "4.2.0",
                 "graceful-fs": "4.1.11",
                 "make-dir": "1.0.0",
                 "unique-string": "1.0.0",
@@ -4435,7 +4563,7 @@
               },
               "dependencies": {
                 "dot-prop": {
-                  "version": "4.1.1",
+                  "version": "4.2.0",
                   "bundled": true,
                   "requires": {
                     "is-obj": "1.0.1"
@@ -4478,6 +4606,30 @@
             "import-lazy": {
               "version": "2.1.0",
               "bundled": true
+            },
+            "is-installed-globally": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "global-dirs": "0.1.0",
+                "is-path-inside": "1.0.0"
+              },
+              "dependencies": {
+                "global-dirs": {
+                  "version": "0.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "ini": "1.3.4"
+                  }
+                },
+                "is-path-inside": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "path-is-inside": "1.0.2"
+                  }
+                }
+              }
             },
             "is-npm": {
               "version": "1.0.0",
@@ -4719,7 +4871,7 @@
           }
         },
         "worker-farm": {
-          "version": "1.5.0",
+          "version": "1.5.1",
           "bundled": true,
           "requires": {
             "errno": "0.1.4",
@@ -5256,9 +5408,9 @@
       }
     },
     "tslib": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-      "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
     },
     "tslint": {
       "version": "5.8.0",
@@ -5274,7 +5426,7 @@
         "minimatch": "3.0.4",
         "resolve": "1.5.0",
         "semver": "5.4.1",
-        "tslib": "1.8.0",
+        "tslib": "1.8.1",
         "tsutils": "2.13.0"
       },
       "dependencies": {
@@ -5311,7 +5463,7 @@
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.0.tgz",
       "integrity": "sha512-FuWzNJbMsp3gcZMbI3b5DomhW4Ia41vMxjN63nKWI0t7f+I3UmHfRl0TrXJTwI2LUduDG+eR1Mksp3pvtlyCFQ==",
       "requires": {
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "tunnel": {
@@ -5339,9 +5491,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.7.0-dev.20171208",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.0-dev.20171208.tgz",
-      "integrity": "sha512-7l5KJiFEKAID5XWNq0egz9ZXDI5cZjzhJd+rthgNPNsZw0RXkMRpmBk8wVpfP4t0rDkiL9WpzvAbEAF2KEGd9w=="
+      "version": "2.7.0-dev.20171212",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.0-dev.20171212.tgz",
+      "integrity": "sha512-D9eP7T4QjfsoFNi35iOYTgLgwQE+OrVkWFQ2p+MbgKd0W2Qupqe6COyyQPoUeXvOrB5rbaIkeomh+VFMOPjtKg=="
     },
     "underscore": {
       "version": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/source-map-support": "^0.4.0",
     "@types/tar": "^1.0.27",
     "@types/yargs": "^8.0.1",
-    "tslint": "^5.5.0"
+    "tslint": "^5.8.0"
   },
   "scripts": {
     "build": "node node_modules/typescript/lib/tsc.js",

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -95,7 +95,7 @@ async function getTypingData(packageName: string, directory: string, ls: Readonl
 	const tsconfig: TsConfig = await readJSON(joinPaths(directory, "tsconfig.json"));
 	const { typeFiles, testFiles } = await entryFilesFromTsConfig(packageName, directory, tsconfig);
 	const { dependencies: dependenciesWithDeclaredModules, globals, declaredModules, declFiles } =
-		await getModuleInfo(packageName, directory, typeFiles, log);
+		await getModuleInfo(packageName, directory, typeFiles);
 	const declaredModulesSet = new Set(declaredModules);
 	// Don't count an import of "x" as a dependency if we saw `declare module "x"` somewhere.
 	const removeDeclaredModules = (modules: Iterable<string>): Iterable<string> => filter(modules, m => !declaredModulesSet.has(m));

--- a/src/npmTags.ts
+++ b/src/npmTags.ts
@@ -5,7 +5,7 @@ import NpmClient from "./lib/npm-client";
 import { AllPackages, AnyPackage } from "./lib/packages";
 import Versions from "./lib/versions";
 
-import { Logger } from "./util/logging";
+import { consoleLogger, Logger } from "./util/logging";
 import { done, nAtATime } from "./util/util";
 
 if (!module.parent) {
@@ -26,8 +26,8 @@ async function tagAll(dry: boolean): Promise<void> {
 		// Only update tags for the latest version of the package.
 		if (pkg.isLatest) {
 			const version = versions.getVersion(pkg).versionString;
-			await updateTypeScriptVersionTags(pkg, version, client, console.log, dry);
-			await updateLatestTag(pkg, versions, client, console.log, dry);
+			await updateTypeScriptVersionTags(pkg, version, client, consoleLogger.info, dry);
+			await updateLatestTag(pkg, versions, client, consoleLogger.info, dry);
 		}
 	});
 

--- a/src/tester/get-affected-packages.ts
+++ b/src/tester/get-affected-packages.ts
@@ -2,14 +2,14 @@ import { Options } from "../lib/common";
 import { parseMajorVersionFromDirectoryName } from "../lib/definition-parser";
 import { AllPackages, PackageBase, TypingsData } from "../lib/packages";
 import { sourceBranch, typesDirectoryName } from "../lib/settings";
-import { Logger } from "../util/logging";
+import { consoleLogger, Logger } from "../util/logging";
 import { done, execAndThrowErrors, flatMap, map, mapDefined, sort } from "../util/util";
 
 if (!module.parent) {
 	done(main(Options.defaults));
 }
 async function main(options: Options): Promise<void> {
-	const changes = await getAffectedPackages(await AllPackages.read(options), console.log, options);
+	const changes = await getAffectedPackages(await AllPackages.read(options), consoleLogger.info, options);
 	console.log({ changedPackages: changes.changedPackages.map(t => t.desc), dependers: changes.dependentPackages.map(t => t.desc) });
 }
 
@@ -39,7 +39,7 @@ function collectDependers(changedPackages: Iterable<TypingsData>, reverseDepende
 }
 
 function sortPackages(packages: Iterable<TypingsData>): TypingsData[] {
-	return sort<TypingsData>(packages, PackageBase.compare);
+	return sort<TypingsData>(packages, PackageBase.compare); // tslint:disable-line no-unbound-method
 }
 
 function transitiveClosure<T>(initialItems: Iterable<T>, getRelatedItems: (item: T) => Iterable<T>): Set<T> {

--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -4,7 +4,7 @@ import * as yargs from "yargs";
 import { Options } from "../lib/common";
 import { AllPackages, PackageBase, TypingsData } from "../lib/packages";
 import { npmInstallFlags } from "../util/io";
-import { LoggerWithErrors, moveLogsWithErrors, quietLoggerWithErrors } from "../util/logging";
+import { consoleLogger, LoggerWithErrors, moveLogsWithErrors, quietLoggerWithErrors } from "../util/logging";
 import { concat, done, exec, execAndThrowErrors, joinPaths, nAtATime, numberOfOsProcesses } from "../util/util";
 
 import getAffectedPackages, { Affected, allDependencies } from "./get-affected-packages";
@@ -41,7 +41,7 @@ export default async function main(options: Options, nProcesses: number, selecti
 	const { changedPackages, dependentPackages }: Affected = selection === "all"
 		? { changedPackages: allPackages.allTypings(), dependentPackages: [] }
 		: selection === "affected"
-		? await getAffectedPackages(allPackages, console.log, options)
+		? await getAffectedPackages(allPackages, consoleLogger.info, options)
 		: { changedPackages: allPackages.allTypings().filter(t => selection.test(t.name)), dependentPackages: [] };
 
 	console.log(`Testing ${changedPackages.length} changed packages: ${changedPackages.map(t => t.desc)}`);

--- a/src/util/logging.ts
+++ b/src/util/logging.ts
@@ -25,8 +25,8 @@ export interface LogWithErrors {
 
 /** Logger that *just* outputs to the console and does not save anything. */
 export const consoleLogger: LoggerWithErrors = {
-	info: console.log,
-	error: console.error
+	info: console.log, // tslint:disable-line no-unbound-method
+	error: console.error, // tslint:disable-line no-unbound-method
 };
 
 /** Logger that *just* records writes and does not output to console. */
@@ -49,7 +49,7 @@ function alsoConsoleLogger(consoleLog: Logger): [Logger, () => Log] {
 
 /** Logger that writes to console in addition to recording a result. */
 export function logger(): [Logger, () => Log]  {
-	return alsoConsoleLogger(console.log);
+	return alsoConsoleLogger(consoleLogger.info);
 }
 
 /** Helper for creating `info` and `error` loggers together. */

--- a/tslint.json
+++ b/tslint.json
@@ -7,15 +7,13 @@
 		"max-line-length": [true, 150],
 		"only-arrow-functions": [true, "allow-declarations"],
 
-		"binary-expression-operand-order": false, //TODO: false positive
-		"cyclomatic-complexity": false, // TODO
-		"no-unsafe-any": false, //TODO
-		"strict-boolean-expressions": false, //TODO
-		"match-default-export-name": false, //TODO
-		"no-unbound-method": false, //TODO: false positives
-		"no-inferred-empty-object-type": false, //TODO: false positive
-		"no-shadowed-variable": false, //TODO
-		"no-unnecessary-type-assertion": false, //TODO: false positive
+		// TODO
+		"no-unsafe-any": false,
+		"strict-boolean-expressions": false,
+		"match-default-export-name": false,
+		"no-inferred-empty-object-type": false, // false positive
+		"no-shadowed-variable": false,
+		"no-unnecessary-type-assertion": false, // false positive
 
 		"no-this-assignment": [true, { "allow-destructuring": true }],
 		"typedef": [true, "call-signature"],


### PR DESCRIPTION
Greatly simplifies the function by separating the external-module and global cases. Now `cyclomatic-complexity` compliant. Fixes a bug where we would consider a source file to declare itself as a module even if it only augmented other modules. Also fixes a bug where we would declare "foo/." instead of "foo".
Removed logging because it just makes the code more complicated and we were never really looking at the logs.