### PR TITLE
Add raven-js to dependenciesWhitelist.txt

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -27,6 +27,7 @@ path-to-regexp
 pkcs11js
 postcss
 protractor
+raven-js
 redux
 redux-persist
 redux-saga


### PR DESCRIPTION
Needed for types for `raven-for-redux` in this PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/22579.