### PR TITLE
Miscellaneous improvements

### DIFF
--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -33,6 +33,15 @@ export class AllPackages {
 		return new TypingsData(raw[versions[0]], /*isLatest*/ true);
 	}
 
+	static async readSingleNotNeeded(name: string, options: Options): Promise<NotNeededPackage> {
+		const notNeeded = await readNotNeededPackages(options);
+		const pkg = notNeeded.find(p => p.name === name);
+		if (pkg === undefined) {
+			throw new Error(`Cannot find not-needed package ${name}`);
+		}
+		return pkg;
+	}
+
 	private constructor(
 		private readonly data: ReadonlyMap<string, TypingsVersions>,
 		private readonly notNeeded: ReadonlyArray<NotNeededPackage>) {}

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -149,6 +149,10 @@ export class Semver {
 		return isPrerelease ? `${major}.${minor}.0-next.${patch}` : `${major}.${minor}.${patch}`;
 	}
 
+	equals(sem: Semver): boolean {
+		return this.major === sem.major && this.minor === sem.minor && this.patch === sem.patch && this.isPrerelease === sem.isPrerelease;
+	}
+
 	greaterThan(sem: Semver): boolean {
 		return this.major > sem.major || this.major === sem.major
 			&& (this.minor > sem.minor || this.minor === sem.minor && this.patch > sem.patch);

--- a/src/publish-registry.ts
+++ b/src/publish-registry.ts
@@ -41,10 +41,11 @@ export default async function main(options: Options, dry: boolean): Promise<void
 	const packageJson = generatePackageJson(newVersion, newContentHash);
 	await generate(registry, packageJson);
 
-	if (highestSemverVersion !== oldVersion) {
+	if (!highestSemverVersion.equals(oldVersion)) {
 		// There was an error in the last publish and types-registry wasn't validated.
 		// This may have just been due to a timeout, so test if types-registry@next is a subset of the one we're about to publish.
 		// If so, we should just update it to "latest" now.
+		log("Old version of types-registry was never tagged latest, so updating");
 		await validateIsSubset(await readNotNeededPackages(options));
 		await client.tag(packageName, highestSemverVersion.versionString, "latest");
 	} else if (oldContentHash !== newContentHash) {


### PR DESCRIPTION
* Semver needs a `equals` method, not `===` since we can have different instances
* Add `node ./bin/publish-packages --deprecate foo` command to try re-deprecating a not-needed package if that failed the first time.
* Remove `unpublish` command since we don't use it, and it won't work anymore anyway.