### PR TITLE
feat: add `magic-string` and `rollup` as dependencies

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -18,6 +18,7 @@ inversify
 jointjs
 levelup
 localforage
+magic-string
 meteor-typings
 mqtt
 moment
@@ -32,6 +33,7 @@ redux
 redux-persist
 redux-saga
 redux-thunk
+rollup
 should
 smooth-scrollbar
 source-map


### PR DESCRIPTION
These are required to remove `@types/rollup` since now it contains it's own typings.