### PR TITLE
chore(DependenciesWhitelist): add D3 to Whitelist to prevent breaking changes

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -8,6 +8,7 @@ chalk
 cordova-plugin-camera
 cordova-plugin-file
 cordova-plugin-file-transfer
+d3
 egg
 electron
 eventemitter2


### PR DESCRIPTION
@andy-ms this is the initial PR to add `d3` for `package.json`-stubs in line with our discussion here: DefinitelyTyped/DefinitelyTyped#23257.