### PR TITLE
Add rxjs and redux-observable to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -31,9 +31,11 @@ postcss
 protractor
 raven-js
 redux
+redux-observable
 redux-persist
 redux-saga
 redux-thunk
+rxjs
 rollup
 should
 smooth-scrollbar


### PR DESCRIPTION
These packages bundle their TypeScript definitions. 

I got the following error when building https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23823

```
Error: In /home/travis/build/DefinitelyTyped/DefinitelyTyped/types/react-redux-epic/package.json: Dependency rxjs not in whitelist.
If you are depending on another `@types` package, do *not* add it to a `package.json`. Path mapping should make the import work.
If this is an external library that provides typings,  please make a pull request to types-publisher adding it to `dependenciesWhitelist.txt`.
```