### PR TITLE
Fix dependency detection for scoped packages

### DIFF
--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -109,7 +109,7 @@ export class AllPackages {
 	/** Returns all of the dependences *that have typings*, ignoring others. */
 	*dependencyTypings(pkg: TypingsData): Iterable<TypingsData> {
 		for (const { name, majorVersion } of pkg.dependencies) {
-			const versions = this.data.get(name);
+			const versions = this.data.get(getMangledNameForScopedPackage(name));
 			if (versions) {
 				yield versions.get(majorVersion);
 			}
@@ -121,12 +121,23 @@ export class AllPackages {
 		yield* this.dependencyTypings(pkg);
 
 		for (const name of pkg.testDependencies) {
-			const versions = this.data.get(name);
+			const versions = this.data.get(getMangledNameForScopedPackage(name));
 			if (versions) {
 				yield versions.getLatest();
 			}
 		}
 	}
+}
+
+// Same as the function in moduleNameResolver.ts in typescript
+function getMangledNameForScopedPackage(packageName: string): string {
+	if (packageName.startsWith("@")) {
+		const replaceSlash = packageName.replace("/", "__");
+		if (replaceSlash !== packageName) {
+			return replaceSlash.slice(1); // Take off the "@"
+		}
+	}
+	return packageName;
 }
 
 export const typesDataFilename = "definitions.json";

--- a/src/tester/get-affected-packages.ts
+++ b/src/tester/get-affected-packages.ts
@@ -24,7 +24,7 @@ export default async function getAffectedPackages(allPackages: AllPackages, log:
 	// If a package doesn't exist, that's because it was deleted.
 	const changedPackages = mapDefined(changedPackageIds, (({ name, majorVersion }) =>
 		majorVersion === "latest" ? allPackages.tryGetLatestVersion(name) : allPackages.tryGetTypingsData({ name, majorVersion })));
-	const dependentPackages = collectDependers(changedPackages,  getReverseDependencies(allPackages));
+	const dependentPackages = collectDependers(changedPackages, getReverseDependencies(allPackages));
 	return { changedPackages, dependentPackages };
 }
 


### PR DESCRIPTION
Previously we would not detect scoped packages as dependencies because we were looking up "@foo/bar" instead of "foo__bar" and getting nothing, thus thinking those dependencies weren't for other DefinitelyTyped packages.