### PR TITLE
Add `popper.js` package to the white-listed dependencies

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -28,6 +28,7 @@ opentracing
 parse5
 path-to-regexp
 pkcs11js
+popper.js
 postcss
 protractor
 raven-js


### PR DESCRIPTION
[Popper.js](https://www.npmjs.com/package/popper.js) is needed for the Bootstrap v4 type definition,
as Bootstrap now depends on Popper and jQuery.