### PR TITLE
Quick fix for missing "deprecated" property from npm info

### DIFF
--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -72,6 +72,7 @@ export default class Versions {
 			const isPrerelease = false; // Not-needed packages are never prerelease.
 			// tslint:disable-next-line:prefer-const
 			let { version, deprecated } = await fetchTypesPackageVersionInfo(pkg, fetcher, isPrerelease) || defaultVersionInfo(isPrerelease);
+			deprecated = true; // TODO: npm randomly fails to return this property and we think it hasn't been deprecated yet.
 			if (!deprecated) {
 				log(`Now deprecated: ${pkg.name}`);
 				changes.push({ name: pkg.name, majorVersion: version.major });


### PR DESCRIPTION
Npm isn't reliably returning this property -- I'll look into getting a proper repro and filing a bug there, but this will get the publisher working without extra publishes for now.