### PR TITLE
Add indefinite-observable to safe list

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -17,6 +17,7 @@ eventemitter3
 fast-glob
 flatpickr
 immutable
+indefinite-observable
 inversify
 jointjs
 levelup


### PR DESCRIPTION
For DefinitelyTyped/DefinitelyTyped#24710, so it can rely on indefinite-observable's types directly instead of copying them into jss.