### PR TITLE
Redue noise in output by not printing OK for happy paths

### DIFF
--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -94,9 +94,7 @@ async function runTests(
 		cwd: options.typesPath,
 		handleOutput(output): void {
 			const { path, status } = output as { path: string, status: string };
-			if (status === "OK") {
-				console.log(`${path} OK`);
-			} else {
+			if (status !== "OK") {
 				console.error(`${path} failing:`);
 				console.error(status);
 				allFailures.push([path, status]);


### PR DESCRIPTION
A better solution is to use a debugger like [debug](https://www.npmjs.com/package/debug) to be able to turn on those loggings. 