### PR TITLE
Add type-zoo to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -47,6 +47,7 @@ smooth-scrollbar
 source-map
 styled-components
 typescript
+type-zoo
 tweetnacl
 vue
 vuex


### PR DESCRIPTION
There are a few utility types that end up getting implemented over and over again from scratch in DefinitelyTyped packages. This package obviates the need for that:

https://github.com/pelotom/type-zoo