### PR TITLE
Add sw-toolbox to safe list

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -46,6 +46,7 @@ should
 smooth-scrollbar
 source-map
 styled-components
+sw-toolbox
 typescript
 tweetnacl
 vue


### PR DESCRIPTION
`sw-precache` depends on `sw-toolbox` declarations.

See also https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25523