### PR TITLE
Add react-native-svg to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -36,6 +36,7 @@ popper.js
 postcss
 protractor
 raven-js
+react-native-svg
 redux
 redux-observable
 redux-persist


### PR DESCRIPTION
This PR adds https://github.com/react-native-community/react-native-svg to whitelist in order to use it's typings in `react-native-svg-charts`.

Related PRs:
* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25880
* https://github.com/JesperLekland/react-native-svg-charts/pull/142