### PR TITLE
Add ethereum-types to the whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -13,6 +13,7 @@ csstype
 decimal.js
 egg
 electron
+ethereum-types
 eventemitter2
 eventemitter3
 fast-glob


### PR DESCRIPTION
Ethereum ecosystem has a lot of packages that share some types that are not actually related to any package, but rather to ethereum in general. I'm planning to add a bunch of typings to DT in the future. I already have definitions ready. [ethereum-types](https://www.npmjs.com/package/ethereum-types) is the package that contains those shared types and will be used for DT definitions.