### PR TITLE
Add tslint to dependenciesWhitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -51,6 +51,7 @@ smooth-scrollbar
 source-map
 styled-components
 sw-toolbox
+tslint
 typescript
 tweetnacl
 vue


### PR DESCRIPTION
While trying to use `@types/fork-ts-checker-webpack-plugin` in a project, I realized it's not including `tslint` as a dependency. Tried to fix that in here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26752

But got an error message on [Travis](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped/builds/395545585#L1751) telling me to add `tslint` to the whitelist in this project. Let me know if this is the right way to make the change! 🙂 