### PR TITLE
Reduce number of processes on travis to 2

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -32,7 +32,7 @@ export function currentTimeStamp(): string {
 	return moment().format("YYYY-MM-DDTHH:mm:ss.SSSZZ");
 }
 
-export const numberOfOsProcesses = process.env.TRAVIS === "true" ? 8 : os.cpus().length;
+export const numberOfOsProcesses = process.env.TRAVIS === "true" ? 2 : os.cpus().length;
 
 /** Progress options needed for `nAtATime`. Other options will be inferred. */
 interface ProgressOptions<T, U> {


### PR DESCRIPTION
Reduce the number of processes in travis environment to 2 as current setup is CPU bound and travis provides just two CPUs (see https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System).

Using more processes results only in higher memory consumption with the risk to hit the 4GB limit of travis containers.

fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26063