### PR TITLE
Add apollo-link and apollo-link-http-common

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -2,6 +2,8 @@ activex-helpers
 ajv
 anydb-sql
 apollo-client
+apollo-link
+apollo-link-http-common
 aws-sdk
 axe-core
 axios


### PR DESCRIPTION
Add [apollo-link](https://www.npmjs.com/package/apollo-link) and [apollo-link-http-common](https://www.npmjs.com/package/apollo-link-http-common) to `dependenciesWhitelist.txt` for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/27094 as mentioned in the [CI Build](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped/builds/400783229)

> Error: In /home/travis/build/DefinitelyTyped/DefinitelyTyped/types/apollo-upload-client/package.json: Dependency apollo-link not in whitelist.
If you are depending on another `@types` package, do *not* add it to a `package.json`. Path mapping should make the import work.
If this is an external library that provides typings,  please make a pull request to types-publisher adding it to `dependenciesWhitelist.txt`.