### PR TITLE
Add dnd-core to dependenciesWhitelist.txt

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -14,6 +14,7 @@ cordova-plugin-file
 cordova-plugin-file-transfer
 csstype
 decimal.js
+dnd-core
 egg
 electron
 eventemitter2


### PR DESCRIPTION
Required to fix types for `react-dnd-multi-backend`