### PR TITLE
Adding "rethinkdbdash" and "rethinkdb" to dependencies whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -48,6 +48,7 @@ redux-observable
 redux-persist
 redux-saga
 redux-thunk
+rethinkdb
 rethinkdbdash
 rxjs
 rollup

--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -48,6 +48,7 @@ redux-observable
 redux-persist
 redux-saga
 redux-thunk
+rethinkdbdash
 rxjs
 rollup
 should


### PR DESCRIPTION
Allow usage of rethinkdbdash external typings from "feathers-rethinkdb" DefinitelyTyped declaration files.

The typings for "rethinkdbdash" are hosted externally [here at types/rethinkdbdash on github](https://github.com/types/rethinkdbdash).

Those "rethinkdbdash" typings extend/depend on "rethinkdb" typings also [externally hosted here at types/rethinkdb on github](https://github.com/types/rethinkdb).

Therefore I have added "rethinkdb" and "rethinkdbdash" to the whitelist so I can consume them from my  "feathers-rethinkdb" DefinitelyTyped typings.