### PR TITLE
Fix bug when re-tagging latest version

### DIFF
--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -123,7 +123,7 @@ export default class Versions {
 	}
 }
 
-export async function changedPackages(allPackages: AllPackages): Promise<AnyPackage[]> {
+export async function changedPackages(allPackages: AllPackages): Promise<ReadonlyArray<AnyPackage>> {
 	const changes = await readChanges();
 	return changes.map(changedPackageName => allPackages.getAnyPackage(changedPackageName));
 }

--- a/src/publish-packages.ts
+++ b/src/publish-packages.ts
@@ -45,7 +45,7 @@ export default async function main(client: NpmClient, dry: boolean, options: Opt
 
 	for (const pkg of packagesShouldPublish) {
 		console.log(`Publishing ${pkg.desc}...`);
-		const publishLog = await publish(pkg, client, allPackages, versions, dry);
+		const publishLog = await publishPackage(client, pkg, packagesShouldPublish, versions, allPackages.getLatest(pkg), dry);
 		writeLogs({ infos: publishLog, errors: [] });
 	}
 
@@ -66,10 +66,6 @@ async function single(client: NpmClient, name: string, options: Options, dry: bo
 	const allPackages = await AllPackages.read(options);
 	const versions = await Versions.load();
 	const pkg = await AllPackages.readSingle(name);
-	const publishLog = await publish(pkg, client, allPackages, versions, dry);
+	const publishLog = await publishPackage(client, pkg, [], versions, allPackages.getLatest(pkg), dry);
 	console.log(publishLog);
-}
-
-function publish(pkg: AnyPackage, client: NpmClient, allPackages: AllPackages, versions: Versions, dry: boolean): Promise<Log> {
-	return publishPackage(client, pkg, versions, allPackages.getLatest(pkg), dry);
 }

--- a/src/util/io.ts
+++ b/src/util/io.ts
@@ -63,7 +63,7 @@ export class Fetcher {
 		try {
 			return JSON.parse(text);
 		} catch (e) {
-			throw new Error(`Bad response from server:\n${text}`);
+			throw new Error(`Bad response from server:\noptions: ${options}\n\n${text}`);
 		}
 	}
 


### PR DESCRIPTION
Previously if `foo/v1` and `foo` (latest) were both being published together, we would publish `foo/v1` first, and immediately after attempt to fix up the "latest" tag to point to the version we were about to publish -- but that caused errors because it didn't exist yet.
Now we will avoid re-tagging a package if we're about to publish a new latest version anyway.