### PR TITLE
add fastify to dependenciesWhitelist.txt

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -20,6 +20,7 @@ electron
 eventemitter2
 eventemitter3
 fast-glob
+fastify
 flatpickr
 immutable
 indefinite-observable


### PR DESCRIPTION
This PR adds fastify to the whitelist so I can depend on it in a definitely typed declaration file for a fastify plugin: fastify-jwt.

For reference: https://github.com/jannikkeye/DefinitelyTyped/tree/fix/%40types/fastify-jwt/types/fastify-jwt

@RyanCavanaugh 