### PR TITLE
add quill-delta to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -73,3 +73,4 @@ vuex
 parchment
 winston
 zipkin
+quill-delta


### PR DESCRIPTION
This will be needed for DefinitelyTyped/DefinitelyTyped#29253.

quill-delta ships its own types which quill is going to need to depend on.