### PR TITLE
Added log4js to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -28,6 +28,7 @@ inversify
 jointjs
 levelup
 localforage
+log4js
 magic-string
 meteor-typings
 mqtt


### PR DESCRIPTION
It bundles types since version 2.3.6. Going to use this in the update for the `karma` type definitions.