### PR TITLE
fix path mapping checks for scoped and versioned packages

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -436,6 +436,11 @@ export function unmangleScopedPackage(packageName: string): string | undefined {
 	return packageName.includes(separator) ? `@${packageName.replace(separator, "/")}` : undefined;
 }
 
+const versionAtEndRegex = /\/v\d+$/;
+export function stripVersion(packageName: string): string {
+	return packageName.replace(versionAtEndRegex, "");
+}
+
 /** Returns [values that cb returned undefined for, defined results of cb]. */
 export function split<T, U>(inputs: ReadonlyArray<T>, cb: (t: T) => U | undefined): [ReadonlyArray<T>, ReadonlyArray<U>] {
 	const keep: T[] = [];


### PR DESCRIPTION
Fixes #506 

Fix how we parse path mappings for scoped and version packages.

Disclaimer: I wasn't sure how to fully test out my changes, please feel free to give things a run through. I did test it on the changes from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29979 though and it seemed to resolve the issues.