### PR TITLE
Generate 'package.json' to contain `"types": "index"`, not `"types": ""`

### DIFF
--- a/src/lib/package-generator.ts
+++ b/src/lib/package-generator.ts
@@ -84,7 +84,7 @@ async function createPackageJSON(typing: TypingsData, version: Semver, packages:
 		license: typing.license,
 		contributors: typing.contributors,
 		main: "",
-		types: "",
+		types: "index",
 		typesVersions:  makeTypesVersionsForPackageJson(typing.typesVersions),
 		repository: {
 			type: "git",


### PR DESCRIPTION
Works around for Microsoft/TypeScript#28304 -- currently `@types/es6-shim` doesn't work in `typescript@next` (or `typescript@3.1`) because the typesVersion redirect doesn't work.