### PR TITLE
Ensure readDir returns sorted results

### DIFF
--- a/src/crawl-npm.ts
+++ b/src/crawl-npm.ts
@@ -6,7 +6,7 @@ import { Options, writeDataFile } from "./lib/common";
 import { UncachedNpmInfoClient } from "./lib/npm-client";
 import { npmRegistry } from "./lib/settings";
 import ProgressBar, { strProgress } from "./util/progress";
-import { done, filterNAtATime } from "./util/util";
+import { done, filterNAtATimeOrdered } from "./util/util";
 
 if (!module.parent) {
 	done(main(Options.defaults));
@@ -17,7 +17,7 @@ async function main(options: Options): Promise<void> {
 	const all = await allNpmPackages();
 	await writeDataFile("all-npm-packages.json", all);
 	const client = new UncachedNpmInfoClient();
-	const allTyped = await filterNAtATime(10, all, pkg => packageHasTypes(pkg, client), {
+	const allTyped = await filterNAtATimeOrdered(10, all, pkg => packageHasTypes(pkg, client), {
 		name: "Checking for types...",
 		flavor: (name, isTyped) => isTyped ? name : undefined,
 		options

--- a/src/parse-definitions.ts
+++ b/src/parse-definitions.ts
@@ -6,7 +6,7 @@ import { getTypingInfo } from "./lib/definition-parser";
 import { definitionParserWorkerFilename, TypingInfoWithPackageName } from "./lib/definition-parser-worker";
 import { AllPackages, readNotNeededPackages, typesDataFilename, TypingsVersionsRaw } from "./lib/packages";
 import { parseNProcesses } from "./tester/test-runner";
-import { assertDefined, done, filterNAtATime, runWithChildProcesses } from "./util/util";
+import { assertDefined, done, filterNAtATimeOrdered, runWithChildProcesses } from "./util/util";
 
 if (!module.parent) {
 	const singleName = yargs.argv.single;
@@ -25,7 +25,7 @@ if (!module.parent) {
 
 export default async function main(dt: FS, parallel?: { readonly nProcesses: number; readonly definitelyTypedPath: string }): Promise<AllPackages> {
 	const typesFS = dt.subDir("types");
-	const packageNames = await filterNAtATime(parallel ? parallel.nProcesses : 1, await typesFS.readdir(), name => typesFS.isDirectory(name));
+	const packageNames = await filterNAtATimeOrdered(parallel ? parallel.nProcesses : 1, await typesFS.readdir(), name => typesFS.isDirectory(name));
 
 	const typings: { [name: string]: TypingsVersionsRaw } = {};
 

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -87,7 +87,7 @@ export function filter<T>(iterable: Iterable<T>, predicate: (value: T) => boolea
 
 export type Awaitable<T> = T | Promise<T>;
 
-export async function filterNAtATime<T>(
+export async function filterNAtATimeOrdered<T>(
 	n: number, inputs: ReadonlyArray<T>, shouldKeep: (input: T) => Awaitable<boolean>, progress?: ProgressOptions<T, boolean>): Promise<T[]> {
 	const shouldKeeps: boolean[] = await nAtATime(n, inputs, shouldKeep, progress);
 	return inputs.filter((_, idx) => shouldKeeps[idx]);
@@ -448,4 +448,13 @@ export function split<T, U>(inputs: ReadonlyArray<T>, cb: (t: T) => U | undefine
 		if (res === undefined) { keep.push(input); } else { splitOut.push(res); }
 	}
 	return [keep, splitOut];
+}
+
+export function assertSorted(a: ReadonlyArray<string>): ReadonlyArray<string> {
+	let prev = "";
+	for (const x of a) {
+		assert(x >= prev, `${x} >= ${prev}`);
+		prev = x;
+	}
+	return a;
 }


### PR DESCRIPTION
Was causing validation failures in publish-registry due to different sorting when downloading from a `.tar.gz`.