### PR TITLE
Allow more logging

### DIFF
--- a/IISNode.yml
+++ b/IISNode.yml
@@ -2,5 +2,5 @@
 loggingEnabled: true
 devErrorsEnabled: false
 maxLogFileSizeInKB: 2048
-maxTotalLogFileSizeInKB: 32768
+maxTotalLogFileSizeInKB: 65536
 maxLogFiles: 16384

--- a/IISNode.yml
+++ b/IISNode.yml
@@ -2,4 +2,5 @@
 loggingEnabled: true
 devErrorsEnabled: false
 maxLogFileSizeInKB: 2048
-maxTotalLogFileSizeInKB: 16384
+maxTotalLogFileSizeInKB: 32768
+maxLogFiles: 16384


### PR DESCRIPTION
1. Retain more than 20 log files.
2. Allow up to ~~32~~ **64** MB of log files. 64 MB should be enough for anybody.

This is still stdout logging; I need to learn how to log to azure from node.