### PR TITLE
Log latency of packages publishes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,45 @@
         }
       }
     },
+    "@octokit/endpoint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.0.tgz",
+      "integrity": "sha512-ANAOhyEY40qzOjQPEYXqg3GDGLYTjLDjqQqcG1wgqRoE7qFLnvx5a0upzxpes83UK/YHUu6qTymZl/yTu4GvKg==",
+      "requires": {
+        "deepmerge": "2.2.1",
+        "is-plain-object": "^2.0.4",
+        "universal-user-agent": "^2.0.1",
+        "url-template": "^2.0.8"
+      }
+    },
+    "@octokit/request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.2.0.tgz",
+      "integrity": "sha512-4P9EbwKZ4xfyupVMb3KVuHmM+aO2fye3nufjGKz/qDssvdJj9Rlx44O0FdFvUp4kIzToy3AHLTOulEIDAL+dpg==",
+      "requires": {
+        "@octokit/endpoint": "^3.0.0",
+        "is-plain-object": "^2.0.4",
+        "node-fetch": "^2.3.0",
+        "universal-user-agent": "^2.0.1"
+      }
+    },
+    "@octokit/rest": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.1.0.tgz",
+      "integrity": "sha512-/D1XokSycOE+prxxI2r9cxssiLMqcr+BsEUjdruC67puEEjNJjJoRIkuA1b20jOkX5Ue3Rz99Mu9rTnNmjetUA==",
+      "requires": {
+        "@octokit/request": "2.2.0",
+        "before-after-hook": "^1.2.0",
+        "btoa-lite": "^1.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.pick": "^4.4.0",
+        "lodash.set": "^4.3.2",
+        "lodash.uniq": "^4.5.0",
+        "octokit-pagination-methods": "^1.1.0",
+        "universal-user-agent": "^2.0.0",
+        "url-template": "^2.0.8"
+      }
+    },
     "@types/charm": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/charm/-/charm-1.0.1.tgz",
@@ -978,6 +1017,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "before-after-hook": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.2.0.tgz",
+      "integrity": "sha512-wI3QtdLppHNkmM1VgRVLCrlWCKk/YexlPicYbXPs4eYdd1InrUCTFsx5bX1iUQzzMsoRXXPpM1r+p7JEJJydag=="
+    },
     "bl": {
       "version": "1.1.2",
       "resolved": "http://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
@@ -1067,6 +1111,11 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
     "buffer-alloc": {
       "version": "1.2.0",
@@ -1446,6 +1495,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
     },
     "default-require-extensions": {
       "version": "1.0.0",
@@ -3029,7 +3083,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       },
@@ -3037,8 +3090,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
     },
@@ -4390,11 +4442,31 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "longjohn": {
       "version": "0.2.12",
@@ -4421,6 +4493,11 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "macos-release": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
+      "integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A=="
     },
     "make-error": {
       "version": "1.3.5",
@@ -4775,6 +4852,16 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -9132,6 +9219,11 @@
         "http-https": "^1.0.0"
       }
     },
+    "octokit-pagination-methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -9185,6 +9277,15 @@
         "execa": "^0.7.0",
         "lcid": "^1.0.0",
         "mem": "^1.1.0"
+      }
+    },
+    "os-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz",
+      "integrity": "sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==",
+      "requires": {
+        "macos-release": "^2.0.0",
+        "windows-release": "^3.1.0"
       }
     },
     "os-tmpdir": {
@@ -10824,6 +10925,14 @@
         }
       }
     },
+    "universal-user-agent": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.2.tgz",
+      "integrity": "sha512-nOwvHWLH3dBazyuzbECPA5uVFNd7AlgviXRHgR4yf48QqitIvpdncRrxMbZNMpPPEfgz30I9ubd1XmiJiqsTrg==",
+      "requires": {
+        "os-name": "^3.0.0"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -10888,6 +10997,11 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
     },
     "use": {
       "version": "3.1.1",
@@ -11035,6 +11149,42 @@
       "optional": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "windows-release": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz",
+      "integrity": "sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==",
+      "requires": {
+        "execa": "^0.10.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        }
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "description": "Publish DefinitelyTyped definitions to NPM",
   "dependencies": {
+    "@octokit/rest": "^16.1.0",
     "@types/tar-stream": "^1.6.0",
     "adal-node": "^0.1.22",
     "applicationinsights": "^1.0.7",

--- a/src/full.ts
+++ b/src/full.ts
@@ -1,6 +1,7 @@
 import * as yargs from "yargs";
 
 import appInsights = require("applicationinsights");
+import Github = require("@octokit/rest");
 import calculateVersions from "./calculate-versions";
 import clean from "./clean";
 import createSearchIndex from "./create-search-index";
@@ -18,11 +19,16 @@ import validate from "./validate";
 if (!module.parent) {
     appInsights.setup();
     appInsights.start();
+    const gh = new Github();
+    gh.authenticate({
+        type: "token",
+        token: process.env["GH_API_TOKEN"] || ""
+    });
     const dry = !!yargs.argv.dry;
-    logUncaughtErrors(full(dry, currentTimeStamp(), Options.defaults));
+    logUncaughtErrors(full(dry, currentTimeStamp(), gh, Options.defaults));
 }
 
-export default async function full(dry: boolean, timeStamp: string, options: Options): Promise<void> {
+export default async function full(dry: boolean, timeStamp: string, github: Github, options: Options): Promise<void> {
     const infoClient = new UncachedNpmInfoClient();
     await clean();
     const dt = await getDefinitelyTyped(options);
@@ -32,7 +38,7 @@ export default async function full(dry: boolean, timeStamp: string, options: Opt
     const changedPackages = await calculateVersions(dt, infoClient);
     await generatePackages(dt, allPackages, changedPackages);
     await createSearchIndex(allPackages, infoClient);
-    await publishPackages(changedPackages, dry);
+    await publishPackages(changedPackages, dry, github);
     await publishRegistry(dt, allPackages, dry, infoClient);
     await validate(dt);
     if (!dry) {

--- a/src/lib/webhook-server.ts
+++ b/src/lib/webhook-server.ts
@@ -1,6 +1,7 @@
 import { createHmac, timingSafeEqual } from "crypto";
 import { createServer, IncomingMessage, Server, ServerResponse } from "http";
 
+import Github = require("@octokit/rest");
 import full from "../full";
 import { Fetcher, stringOfStream } from "../util/io";
 import { joinLogWithErrors, LoggerWithErrors, loggerWithErrors, LogWithErrors } from "../util/logging";
@@ -19,11 +20,16 @@ export default async function webhookServer(
     options: Options,
 ): Promise<Server> {
     return listenToGithub(key, githubAccessToken, fetcher, updateOneAtATime(async (log, timeStamp) => {
+        const github = new Github();
+        github.authenticate({
+            type: "token",
+            token: githubAccessToken
+        });
         log.info(""); log.info("");
         log.info(`# ${timeStamp}`);
         log.info("");
         log.info("Starting full...");
-        await full(dry, timeStamp, options);
+        await full(dry, timeStamp, github, options);
     }));
 }
 

--- a/src/publish-packages.ts
+++ b/src/publish-packages.ts
@@ -1,5 +1,7 @@
 import * as yargs from "yargs";
 
+import appInsights = require("applicationinsights");
+import Github = require("@octokit/rest");
 import { getDefinitelyTyped } from "./get-definitely-typed";
 import { Options } from "./lib/common";
 import { NpmPublishClient } from "./lib/npm-client";
@@ -12,6 +14,11 @@ import { logUncaughtErrors } from "./util/util";
 if (!module.parent) {
     const dry = !!yargs.argv.dry;
     const deprecateName = yargs.argv.deprecate as string | undefined;
+    const gh = new Github();
+    gh.authenticate({
+        type: "token",
+        token: process.env["GH_API_TOKEN"] || ""
+    });
     logUncaughtErrors(async () => {
         const dt = await getDefinitelyTyped(Options.defaults);
         if (deprecateName !== undefined) {
@@ -19,12 +26,12 @@ if (!module.parent) {
             // Normally this should not be needed.
             await deprecateNotNeededPackage(await NpmPublishClient.create(), await AllPackages.readSingleNotNeeded(deprecateName, dt));
         } else {
-            await publishPackages(await readChangedPackages(await AllPackages.read(dt)), dry);
+            await publishPackages(await readChangedPackages(await AllPackages.read(dt)), dry, gh);
         }
     });
 }
 
-export default async function publishPackages(changedPackages: ChangedPackages, dry: boolean): Promise<void> {
+export default async function publishPackages(changedPackages: ChangedPackages, dry: boolean, github: Github): Promise<void> {
     const [log, logResult] = logger();
     if (dry) {
         log("=== DRY RUN ===");
@@ -35,6 +42,23 @@ export default async function publishPackages(changedPackages: ChangedPackages, 
     for (const cp of changedPackages.changedTypings) {
         console.log(`Publishing ${cp.pkg.desc}...`);
         await publishTypingsPackage(client, cp, dry, log);
+        const commits = (await github.repos.listCommits({
+            owner: "DefinitelyTyped",
+            repo: "DefinitelyTyped",
+            path: "types/" + cp.pkg.desc,
+            per_page: 1
+        })).data;
+        if (commits.length > 0) {
+            const latency = Date.now() - new Date(commits[0].commit.author.date).valueOf();
+            appInsights.defaultClient.trackEvent({
+                name: "publish package",
+                properties: {
+                    name: cp.pkg.desc,
+                    latency: latency.toString()
+                }
+            });
+            appInsights.defaultClient.trackMetric({ name: "publish latency", value: latency });
+        }
     }
     for (const n of changedPackages.changedNotNeededPackages) {
         await publishNotNeededPackage(client, n, dry, log);


### PR DESCRIPTION
Add a reference to the JS REST wrapper, `@octokit/rest` since I am lazy. It measures the difference in time between the completion of publishing a package and the commit time for the corresponding directory in DefinitelyTyped.

Locally, add an environment variable GH_API_TOKEN to test this. In normal usage, it will use the same token that the rest of the server uses.