### PR TITLE
add google dependencies to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -22,6 +22,8 @@ eventemitter3
 fast-glob
 fastify
 flatpickr
+google-auth-library
+google-gax
 grpc
 graphql-tools
 immutable


### PR DESCRIPTION
These dependencies provide external typings for some npm packages I have just finished creating types for.

> If this is an external library that provides typings,  please make a pull request to types-publisher adding it to \`dependenciesWhitelist.txt\`.`;
