### PR TITLE
Improve types-registry validation

### DIFF
--- a/src/npmTags.ts
+++ b/src/npmTags.ts
@@ -22,11 +22,7 @@ async function tag(dry: boolean, name?: string): Promise<void> {
     const publishClient = await NpmPublishClient.create();
     await CachedNpmInfoClient.with(new UncachedNpmInfoClient(),  async infoClient => {
         if (name) {
-            const pkgs = await AllPackages.readLatestTypings();
-            const pkg = pkgs.find(pkg => pkg.fullNpmName === "@types/" + name)
-            if (!pkg) {
-                throw new Error(`couldn't find ${name}; ${pkgs[0].fullNpmName}`);
-            }
+            const pkg = await AllPackages.readSingle(name);
             const version = await getLatestTypingVersion(pkg, infoClient);
             await updateTypeScriptVersionTags(pkg, version, publishClient, consoleLogger.info, dry);
             await updateLatestTag(pkg.fullEscapedNpmName, version, publishClient, consoleLogger.info, dry);

--- a/src/publish-registry.ts
+++ b/src/publish-registry.ts
@@ -8,9 +8,10 @@ import { CachedNpmInfoClient, NpmPublishClient, UncachedNpmInfoClient } from "./
 import { AllPackages, NotNeededPackage, readNotNeededPackages, TypingsData } from "./lib/packages";
 import { outputDirPath, validateOutputPath } from "./lib/settings";
 import { fetchAndProcessNpmInfo } from "./lib/versions";
-import { assertDirectoriesEqual, npmInstallFlags, readJson, sleep, writeFile, writeJson } from "./util/io";
+import { npmInstallFlags, readJson, sleep, writeFile, writeJson } from "./util/io";
 import { logger, writeLog } from "./util/logging";
 import { computeHash, execAndThrowErrors, joinPaths, logUncaughtErrors } from "./util/util";
+import { log } from "util";
 
 const packageName = "types-registry";
 const registryOutputPath = joinPaths(outputDirPath, packageName);
@@ -121,22 +122,31 @@ const validateTypesRegistryPath = joinPaths(validateOutputPath, "node_modules", 
 
 async function validate(): Promise<void> {
     await installForValidate();
-    await assertDirectoriesEqual(registryOutputPath, validateTypesRegistryPath, {
-        ignore: f => f === "package.json",
-    });
+    assertJsonSuperset(
+        await readJson(joinPaths(registryOutputPath, "index.json")),
+        await readJson(joinPaths(validateTypesRegistryPath, "index.json")));
 }
 
 async function validateIsSubset(notNeeded: ReadonlyArray<NotNeededPackage>): Promise<void> {
     await installForValidate();
     const indexJson = "index.json";
-    await assertDirectoriesEqual(registryOutputPath, validateTypesRegistryPath, {
-        ignore: f => f === "package.json" || f === indexJson,
-    });
     const actual = await readJson(joinPaths(validateTypesRegistryPath, indexJson)) as Registry;
     const expected = await readJson(joinPaths(registryOutputPath, indexJson)) as Registry;
     for (const key in actual.entries) {
         if (!(key in expected.entries) && !notNeeded.some(p => p.name === key)) {
             throw new Error(`Actual types-registry has unexpected key ${key}`);
+        }
+    }
+}
+
+function assertJsonSuperset(superset: { [s: string]: any }, subset: { [s: string]: any }, parent = "") {
+    for (const key of Object.keys(subset)) {
+        assert(superset.hasOwnProperty(key), `${key} in ${parent} was not found in superset`);
+        if (typeof superset[key] === "string" || typeof superset[key] === "number" || typeof superset[key] === "boolean") {
+            assert(superset[key] === subset[key], `${key} in ${parent} did not match: superset[key] (${superset[key]} !== subset[key] (${subset[key]})`);
+        }
+        else {
+            assertJsonSuperset(superset[key], subset[key], key);
         }
     }
 }
@@ -163,7 +173,13 @@ function generatePackageJson(version: string, typesPublisherContentHash: string)
     };
 }
 
-interface Registry { readonly entries: { readonly [packageName: string]: { readonly [distTags: string]: string } }; }
+interface Registry {
+    readonly entries: {
+        readonly [packageName: string]: {
+            readonly [distTags: string]: string
+        }
+    };
+}
 async function generateRegistry(typings: ReadonlyArray<TypingsData>, client: CachedNpmInfoClient): Promise<Registry> {
     const entries: { [packageName: string]: { [distTags: string]: string } } = {};
     for (const typing of typings) {
@@ -171,8 +187,9 @@ async function generateRegistry(typings: ReadonlyArray<TypingsData>, client: Cac
         const info = client.getNpmInfoFromCache(typing.fullEscapedNpmName);
         if (!info) {
             const missings = typings.filter(t => !client.getNpmInfoFromCache(t.fullEscapedNpmName)).map(t => t.fullEscapedNpmName);
-            throw new Error(`${missings} not found in ${Array.from(client.formatKeys())}`);
+            throw new Error(`${missings} not found in ${client.formatKeys()}`);
         }
+        if (typing.name==='activex-excel') log('hiiii')
         entries[typing.name] = filterTags(info.distTags);
     }
     return { entries };

--- a/src/publish-registry.ts
+++ b/src/publish-registry.ts
@@ -11,7 +11,6 @@ import { fetchAndProcessNpmInfo } from "./lib/versions";
 import { npmInstallFlags, readJson, sleep, writeFile, writeJson } from "./util/io";
 import { logger, writeLog } from "./util/logging";
 import { computeHash, execAndThrowErrors, joinPaths, logUncaughtErrors } from "./util/util";
-import { log } from "util";
 
 const packageName = "types-registry";
 const registryOutputPath = joinPaths(outputDirPath, packageName);
@@ -189,7 +188,6 @@ async function generateRegistry(typings: ReadonlyArray<TypingsData>, client: Cac
             const missings = typings.filter(t => !client.getNpmInfoFromCache(t.fullEscapedNpmName)).map(t => t.fullEscapedNpmName);
             throw new Error(`${missings} not found in ${client.formatKeys()}`);
         }
-        if (typing.name==='activex-excel') log('hiiii')
         entries[typing.name] = filterTags(info.distTags);
     }
     return { entries };

--- a/src/util/io.ts
+++ b/src/util/io.ts
@@ -137,16 +137,4 @@ export async function isDirectory(path: string): Promise<boolean> {
     return (await stat(path)).isDirectory();
 }
 
-export function assertJsonSuperset(superset: { [s: string]: any }, subset: { [s: string]: any }, parent = "") {
-    for (const key of Object.keys(subset)) {
-        assert(superset.hasOwnProperty(key), key);
-        if (typeof superset[key] === "string" || typeof superset[key] === "number" || typeof superset[key] === "boolean") {
-            assert(superset[key] === subset[key], `${key} in ${parent} did not match: superset[key] (${superset[key]} !== subset[key] (${subset[key]})`);
-        }
-        else {
-            assertJsonSuperset(superset[key], subset[key], key);
-        }
-    }
-}
-
 export const npmInstallFlags = "--ignore-scripts --no-shrinkwrap --no-package-lock --no-bin-links --no-save";


### PR DESCRIPTION
1. Improve types-registry validation. It's a JSON superset of the only file
that matters now. Note that it still currently fails because of a bug in
the publishing of types-registry.
2. Simplify npmTags code a little
3. Move/remove unneeded utils