### PR TITLE
Correct fix for global references

### DIFF
--- a/src/lib/module-info.ts
+++ b/src/lib/module-info.ts
@@ -175,7 +175,7 @@ async function resolveModule(importSpecifier: string, fs: FS): Promise<string> {
 interface Reference {
     /** <reference path> includes exact filename, so true. import "foo" may reference "foo.d.ts" or "foo/index.d.ts", so false. */
     readonly exact: boolean;
-    readonly text: string;
+    text: string;
 }
 
 /**
@@ -194,17 +194,18 @@ function* findReferencedFiles(src: ts.SourceFile, subDirectory: string, baseDire
         }
     }
 
-    function addReference({ exact, text }: Reference): Reference {
+    function addReference(ref: Reference): Reference {
         // `path.normalize` may add windows slashes
-        const full = normalizeSlashes(path.normalize(joinPaths(subDirectory, assertNoWindowsSlashes(src.fileName, text))));
+        const full = normalizeSlashes(path.normalize(joinPaths(subDirectory, assertNoWindowsSlashes(src.fileName, ref.text))));
         // allow files in typesVersions directories (i.e. 'ts3.1') to reference files in parent directory
-        if (full.startsWith("..") && (baseDirectory === "." || path.normalize(joinPaths(baseDirectory, full)).startsWith(".."))) {
+        if (full.startsWith("..") && (baseDirectory === "" || path.normalize(joinPaths(baseDirectory, full)).startsWith(".."))) {
             throw new Error(
                 `${src.fileName}: ` +
                 'Definitions must use global references to other packages, not parent ("../xxx") references.' +
-                `(Based on reference '${text}')`);
+                `(Based on reference '${ref.text}')`);
         }
-        return { exact, text: full };
+        ref.text = full;
+        return ref;
     }
 }
 

--- a/src/lib/package-generator.ts
+++ b/src/lib/package-generator.ts
@@ -20,7 +20,6 @@ export async function generateTypingPackage(typing: TypingsData, packages: AllPa
     const packageJson = createPackageJSON(typing, version, packages);
     await writeCommonOutputs(typing, packageJson, createReadme(typing));
     await Promise.all(typing.files.
-                      filter(file => !file.startsWith("..")).
                       map(async file => writeFile(await outputFilePath(typing, file), await packageFS.readFile(file))));
 }
 


### PR DESCRIPTION
There exists a fix to prevent global references to other packages, but
it checked the wrong value for baseDirectory. It should be "" not ".".

This also reverts the temporary fix.