### PR TITLE
Add ast-types and recast to dependenciesWhitelist.txt

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -19,6 +19,7 @@ anydb-sql
 apollo-client
 apollo-link
 apollo-link-http-common
+ast-types
 aws-sdk
 axe-core
 axios
@@ -70,6 +71,7 @@ raven-js
 react-dnd
 react-native-maps
 react-native-svg
+recast
 redux
 redux-observable
 redux-persist


### PR DESCRIPTION
Add ast-types and recast to dependenciesWhitelist.txt, as per this [DefinitelyTyped build failure](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped/builds/477629074) recommendation:

```
Error: In package.json: Dependency ast-types not in whitelist.
If you are depending on another `@types` package, do *not* add it to a `package.json`. Path mapping should make the import work.
If this is an external library that provides typings,  please make a pull request to types-publisher adding it to `dependenciesWhitelist.txt`.
    at checkPackageJsonDependencies (/home/travis/build/DefinitelyTyped/DefinitelyTyped/node_modules/types-publisher/src/lib/definition-parser.ts:199:19)
    at combineDataForAllTypesVersions (/home/travis/build/DefinitelyTyped/DefinitelyTyped/node_modules/types-publisher/src/lib/definition-parser.ts:99:37)
    at <anonymous>
Error: Parsing failed.
    at fail (/home/travis/build/DefinitelyTyped/DefinitelyTyped/node_modules/types-publisher/src/util/util.ts:338:20)
    at ChildProcess.child.on (/home/travis/build/DefinitelyTyped/DefinitelyTyped/node_modules/types-publisher/src/util/util.ts:326:21)
    at emitNone (events.js:106:13)
    at ChildProcess.emit (events.js:208:7)
    at finish (internal/child_process.js:747:14)
    at _combinedTickCallback (internal/process/next_tick.js:132:7)
    at process._tickCallback (internal/process/next_tick.js:181:9)
npm ERR! Test failed.  See above for more details.
The command "npm test" exited with 1.
```

Related PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32020

Reviewer: @sandersn