### PR TITLE
Add broadcast-channel to the  dependenciesWhitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -23,6 +23,7 @@ aws-sdk
 axe-core
 axios
 bignumber.js
+broadcast-channel
 chalk
 cordova-plugin-camera
 cordova-plugin-file
@@ -90,4 +91,3 @@ vue-router
 vuex
 winston
 zipkin
-broadcast-channel

--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -90,3 +90,4 @@ vue-router
 vuex
 winston
 zipkin
+broadcast-channel


### PR DESCRIPTION
```
Error: In package.json: Dependency broadcast-channel not in whitelist.
If you are depending on another `@types` package, do *not* add it to a `package.json`. Path mapping should make the import work.
If this is an external library that provides typings,  please make a pull request to types-publisher adding it to `dependenciesWhitelist.txt`.
    at checkPackageJsonDependencies (/Users/muaohua/Documents/git/DefinitelyTyped/node_modules/types-publisher/src/lib/definition-parser.ts:199:19)
    at combineDataForAllTypesVersions (/Users/muaohua/Documents/git/DefinitelyTyped/node_modules/types-publisher/src/lib/definition-parser.ts:99:37)
Error: Parsing failed.
    at fail (/Users/muaohua/Documents/git/DefinitelyTyped/node_modules/types-publisher/src/util/util.ts:338:20)
    at ChildProcess.child.on (/Users/muaohua/Documents/git/DefinitelyTyped/node_modules/types-publisher/src/util/util.ts:326:21)
    at ChildProcess.emit (events.js:182:13)
    at finish (internal/child_process.js:797:14)
    at process._tickCallback (internal/process/next_tick.js:61:11)
```