### PR TITLE
Make "projectName" clickable

### DIFF
--- a/src/lib/package-generator.ts
+++ b/src/lib/package-generator.ts
@@ -132,7 +132,7 @@ function createReadme(typing: TypingsData): string {
 
     lines.push("# Summary");
     if (typing.projectName) {
-        lines.push(`This package contains type definitions for ${typing.libraryName} (${typing.projectName}).`);
+        lines.push(`This package contains type definitions for ${typing.libraryName} ( ${typing.projectName} ).`);
     } else {
         lines.push(`This package contains type definitions for ${typing.libraryName}.`);
     }


### PR DESCRIPTION
The "This package contains type definitions for..." section has the "projectName" in paranthesis.
The projectName is almost always a URL (all but 10 what I could see in DT), but because of the paranthesis, it seems like npm doesn't convert it to a link, which is a shame.

I tried researching what process npmjs.com uses when highlighting links if there was a nicer way of getting the link to be converted. I also considered to replace the lin with `[url](url)` to keep it in paranthesis, but as far as I can see, the "projectName" doesn't HAVE to be a url, even if it usually is, so always treating it like a URL is probably incorrect. Could also have some code to try to identify if the projectname is a URL and if so, use explicit link `[a](a)` syntax. This has the possibility of being incorrect however.

Simply adding spaces inside the paranthesis, while not pretty, is a simple solution to ensure that npmjs.com picks up and highlights the URL. 