### PR TITLE
Update azure-keyvault from 1.0 to 3.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -704,23 +704,13 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
-    "azure-arm-resource": {
-      "version": "1.6.1-preview",
-      "resolved": "http://registry.npmjs.org/azure-arm-resource/-/azure-arm-resource-1.6.1-preview.tgz",
-      "integrity": "sha1-qppJ+5CBohDy9MxllspGU7aDBuY=",
-      "requires": {
-        "ms-rest": "^1.14.0",
-        "ms-rest-azure": "^1.14.0"
-      }
-    },
     "azure-keyvault": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/azure-keyvault/-/azure-keyvault-1.0.0.tgz",
-      "integrity": "sha1-1jD5gDKq27XnL7BNLaSbNo5EHJ4=",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/azure-keyvault/-/azure-keyvault-3.0.4.tgz",
+      "integrity": "sha1-t3M9j1jZmmb5rnZkUVVus7BY2uU=",
       "requires": {
-        "ms-rest": "^1.14.5",
-        "ms-rest-azure": "^1.14.5",
-        "underscore": "^1.4.0"
+        "ms-rest": "^2.3.2",
+        "ms-rest-azure": "^2.5.5"
       }
     },
     "azure-storage": {
@@ -1036,14 +1026,6 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
         "inherits": "~2.0.0"
-      }
-    },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "requires": {
-        "hoek": "2.x.x"
       }
     },
     "brace-expansion": {
@@ -1372,7 +1354,8 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "optional": true
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -1408,14 +1391,6 @@
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
-      }
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "requires": {
-        "boom": "2.x.x"
       }
     },
     "cssom": {
@@ -1648,7 +1623,7 @@
       "version": "github:Microsoft/dtslint#7e6edb313a931459274e359fa0234e011c09c196",
       "from": "github:Microsoft/dtslint#production",
       "requires": {
-        "definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#56d9f98e9acc5b4c0062aa919850b306a7616693",
+        "definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
         "fs-extra": "^6.0.1",
         "strip-json-comments": "^2.0.1",
         "tslint": "^5.12.0",
@@ -1722,7 +1697,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "ecc-jsbn": {
@@ -2304,7 +2279,8 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
@@ -2329,6 +2305,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2508,7 +2485,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2614,7 +2592,8 @@
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2649,22 +2628,6 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
         "wide-align": "^1.1.0"
-      }
-    },
-    "generate-function": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "requires": {
-        "is-property": "^1.0.2"
-      }
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "requires": {
-        "is-property": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -2877,22 +2840,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
-      }
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -3002,8 +2949,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -3121,23 +3067,6 @@
         "is-extglob": "^1.0.0"
       }
     },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
-    },
-    "is-my-json-valid": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
-      "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -3173,11 +3102,6 @@
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-regex": {
       "version": "1.0.4",
@@ -4405,11 +4329,6 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
       "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
     },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4728,144 +4647,40 @@
       "dev": true
     },
     "ms-rest": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-1.15.7.tgz",
-      "integrity": "sha1-QAUV4FsZJIicthoexgVCkKaOEgc=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.4.0.tgz",
+      "integrity": "sha512-eduuuoCxKwjdsP/zxmE93zrccs7xwvef799Uoz+HE0HYiOR9I2j+hPUNF0p8Ik2rt9SJiRrDiP/EcpannaFbPQ==",
       "requires": {
-        "duplexer": "~0.1.1",
-        "moment": "^2.14.1",
-        "request": "~2.74.0",
-        "through": "~2.3.4",
-        "tunnel": "~0.0.2",
-        "uuid": "^3.0.1"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-        },
-        "form-data": {
-          "version": "1.0.1",
-          "resolved": "http://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
-          "requires": {
-            "async": "^2.0.1",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.11"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "requires": {
-            "chalk": "^1.1.1",
-            "commander": "^2.9.0",
-            "is-my-json-valid": "^2.12.4",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        },
-        "qs": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-          "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
-        },
-        "request": {
-          "version": "2.74.0",
-          "resolved": "http://registry.npmjs.org/request/-/request-2.74.0.tgz",
-          "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "bl": "~1.1.2",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~1.0.0-rc4",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "node-uuid": "~1.4.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.2.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-          "requires": {
-            "punycode": "^1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-        }
+        "duplexer": "^0.1.1",
+        "is-buffer": "^1.1.6",
+        "is-stream": "^1.1.0",
+        "moment": "^2.21.0",
+        "request": "^2.88.0",
+        "through": "^2.3.8",
+        "tunnel": "0.0.5",
+        "uuid": "^3.2.1"
       }
     },
     "ms-rest-azure": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/ms-rest-azure/-/ms-rest-azure-1.15.7.tgz",
-      "integrity": "sha1-i84J8FOxVl26qL0CLKQBVcNbD94=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/ms-rest-azure/-/ms-rest-azure-2.6.0.tgz",
+      "integrity": "sha512-J6386a9krZ4VtU7CRt+Ypgo9RGf8+d3gjMBkH7zbkM4zzkhbbMOYiPRaZ+bHZcfihkKLlktTgA6rjshTjF329A==",
       "requires": {
-        "adal-node": "^0.1.17",
-        "async": "0.2.7",
-        "azure-arm-resource": "^1.6.1-preview",
-        "moment": "^2.14.1",
-        "ms-rest": "^1.15.7",
-        "uuid": "^3.0.1"
+        "adal-node": "^0.1.28",
+        "async": "2.6.0",
+        "moment": "^2.22.2",
+        "ms-rest": "^2.3.2",
+        "request": "^2.88.0",
+        "uuid": "^3.2.1"
       },
       "dependencies": {
         "async": {
-          "version": "0.2.7",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.2.7.tgz",
-          "integrity": "sha1-RMXuFRrs5sS/U2TPx8KP5OWPGN8="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "requires": {
+            "lodash": "^4.14.0"
+          }
         }
       }
     },
@@ -8346,12 +8161,14 @@
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -9191,14 +9008,6 @@
         "kind-of": "^3.2.0"
       }
     },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "requires": {
-        "hoek": "2.x.x"
-      }
-    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -9371,11 +9180,6 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "stringstream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -9560,7 +9364,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmpl": {
@@ -9766,9 +9570,9 @@
       }
     },
     "tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.5.tgz",
+      "integrity": "sha512-gj5sdqherx4VZKMcBA4vewER7zdK25Td+z1npBqpbDys4eJrLx+SlYjJvq1bDXs2irkuJM5pf8ktaEQVipkrbA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@types/tar-stream": "^1.6.0",
     "adal-node": "^0.1.22",
     "applicationinsights": "^1.0.7",
-    "azure-keyvault": "^1.0.0",
+    "azure-keyvault": "^3.0.4",
     "azure-storage": "^2.0.0",
     "charm": "^1.0.2",
     "definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",

--- a/src/lib/secrets.ts
+++ b/src/lib/secrets.ts
@@ -49,10 +49,8 @@ function azureSecretName(secret: Secret): string {
 
 export function getSecret(secret: Secret): Promise<string> {
     const client = getClient();
-    const secretUrl = `${azureKeyvault}/secrets/${azureSecretName(secret)}`;
-
     return new Promise<string>((resolve, reject) => {
-        client.getSecret(secretUrl, (error, bundle) => {
+        client.getSecret(azureKeyvault, azureSecretName(secret), process.env.TYPES_PUBLISHER_CLIENT_SECRET_VERSION!, (error, bundle) => {
             if (error) {
                 reject(error);
             } else {
@@ -65,22 +63,18 @@ export function getSecret(secret: Secret): Promise<string> {
 function getClient(): KeyVaultClient {
     const clientId = process.env.TYPES_PUBLISHER_CLIENT_ID;
     const clientSecret = process.env.TYPES_PUBLISHER_CLIENT_SECRET;
-    if (!(clientId && clientSecret)) {
-        throw new Error("Must set the TYPES_PUBLISHER_CLIENT_ID and TYPES_PUBLISHER_CLIENT_SECRET environment variables.");
+    const clientSecretVersion = process.env.TYPES_PUBLISHER_CLIENT_SECRET_VERSION;
+    if (!(clientId && clientSecret && clientSecretVersion)) {
+        throw new Error("Must set the TYPES_PUBLISHER_CLIENT_ID, TYPES_PUBLISHER_CLIENT_SECRET and TYPES_PUBLISHER_CLIENT_SECRET_VERSION environment variables.");
     }
 
-    // Authenticator - retrieves the access token
+    // Copied from example usage at https://www.npmjs.com/package/azure-keyvault
     const credentials = new KeyVaultCredentials((challenge, callback) => {
-        // Create a new authentication context.
         const context = new AuthenticationContext(challenge.authorization);
-
-        // Use the context to acquire an authentication token.
         context.acquireTokenWithClientCredentials(challenge.resource, clientId, clientSecret, (error, tokenResponse) => {
             if (error) {
                 throw error;
             }
-
-            // Calculate the value to be set in the request's Authorization header and resume the call.
             callback(undefined, `${tokenResponse!.tokenType} ${tokenResponse!.accessToken}`);
         });
     });

--- a/src/types/azure-keyvault.d.ts
+++ b/src/types/azure-keyvault.d.ts
@@ -9,7 +9,7 @@ interface Challenge {
 
 export class KeyVaultClient {
     constructor(credentials: KeyVaultCredentials);
-    getSecret(uri: string, callback: (error: Error | null | undefined, secretBundle: SecretBundle | null | undefined) => void): void;
+    getSecret(vaultBaseUrl: string, secretName: string, secretVersion: string, callback: (error: Error | null | undefined, secretBundle: SecretBundle | null | undefined) => void): Promise<SecretBundle>;
 }
 
 interface SecretBundle {


### PR DESCRIPTION
*As far as I can tell*, `getSecret` now requires a version string, so I added an environment variable for that. This whole thing seems way too complicated.

The azure documentation is horrible, and at least as of version 1.0, there were no types despite the library being written in Typescript.

So I'm going to ship it and see how it breaks.