### PR TITLE
Add exports for parsing Definitely Typed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
+export { getDefinitelyTyped } from "./get-definitely-typed";
 export { CachedNpmInfoClient, NpmPublishClient, UncachedNpmInfoClient } from "./lib/npm-client";
 export { AllPackages } from "./lib/packages";
 export { getLatestTypingVersion } from "./lib/versions";
+export { default as parseDefinitions } from "./parse-definitions";
 
-export { consoleLogger } from "./util/logging";
+export { parseNProcesses } from "./tester/test-runner";
+export { consoleLogger, loggerWithErrors } from "./util/logging";
 export { logUncaughtErrors, nAtATime } from "./util/util";
 
 export { updateLatestTag, updateTypeScriptVersionTags } from "./lib/package-publisher";
+


### PR DESCRIPTION
Turns out this is a pre-requisite for changing npm tags.