### PR TITLE
Simplify parse definition

### DIFF
--- a/src/lib/definition-parser-worker.ts
+++ b/src/lib/definition-parser-worker.ts
@@ -5,32 +5,21 @@ import { getLocallyInstalledDefinitelyTyped } from "../get-definitely-typed";
 import { logUncaughtErrors } from "../util/util";
 
 import { getTypingInfo } from "./definition-parser";
-import { TypingsVersionsRaw } from "./packages";
+
+// This file is "called" by runWithChildProcesses from parse-definition.ts
+export const definitionParserWorkerFilename = __filename;
 
 if (!module.parent) {
     process.on("message", message => {
         assert(process.argv.length === 3);
         const typesPath = process.argv[2];
-        logUncaughtErrors(go(message as ReadonlyArray<string>, typesPath));
+        logUncaughtErrors(async () => {
+            for (const packageName of message as ReadonlyArray<string>) {
+                const data = await getTypingInfo(packageName, getLocallyInstalledDefinitelyTyped(typesPath).subDir(packageName));
+                process.send!({ data, packageName });
+            }
+        });
     });
 }
 
-export const definitionParserWorkerFilename = __filename;
 
-export interface DefinitionParserWorkerArgs {
-    readonly packageName: string;
-    readonly typesPath: string;
-}
-
-export interface TypingInfoWithPackageName {
-    readonly data: TypingsVersionsRaw;
-    readonly packageName: string;
-}
-
-async function go(packageNames: ReadonlyArray<string>, typesPath: string): Promise<void> {
-    for (const packageName of packageNames) {
-        const data = await getTypingInfo(packageName, getLocallyInstalledDefinitelyTyped(typesPath).subDir(packageName));
-        const result: TypingInfoWithPackageName = { data, packageName };
-        process.send!(result);
-    }
-}

--- a/src/parse-definitions.test.ts
+++ b/src/parse-definitions.test.ts
@@ -1,0 +1,24 @@
+import parseDefinitions from "./parse-definitions";
+import { getDefinitelyTyped } from "./get-definitely-typed";
+import { Options } from "./lib/common";
+import { loggerWithErrors } from "./util/logging";
+
+function testo(o: { [s: string]: () => void }) {
+    for (const k in o) {
+        test(k, o[k], 100_000);
+    }
+}
+testo({
+    async parseDefinitions() {
+        const log = loggerWithErrors()[0]
+        const dt = await getDefinitelyTyped(Options.defaults, log);
+        const defs = await parseDefinitions(dt, undefined, log)
+        expect(defs.allNotNeeded().length).toBeGreaterThan(0)
+        expect(defs.allTypings().length).toBeGreaterThan(5000)
+        const j = defs.tryGetLatestVersion("jquery")
+        expect(j).toBeDefined()
+        expect(j!.fullNpmName).toContain("types")
+        expect(j!.fullNpmName).toContain("jquery")
+        expect(defs.allPackages().length).toEqual(defs.allTypings().length + defs.allNotNeeded().length)
+    },
+});

--- a/src/parse-definitions.test.ts
+++ b/src/parse-definitions.test.ts
@@ -11,6 +11,7 @@ function testo(o: { [s: string]: () => void }) {
 testo({
     async parseDefinitions() {
         const log = loggerWithErrors()[0]
+        // TODO: A mocked DT would be really nice here
         const dt = await getDefinitelyTyped(Options.defaults, log);
         const defs = await parseDefinitions(dt, undefined, log)
         expect(defs.allNotNeeded().length).toBeGreaterThan(0)


### PR DESCRIPTION
1. Add a test for parse-definitions.
2. Document definition-parser-worker.
3. Simplify code: introduce a little duplication in exchange for removing a lot of indirection.