### PR TITLE
Add "handlebars" to the dependenciesWhitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -44,6 +44,7 @@ google-auth-library
 google-gax
 graphql-tools
 grpc
+handlebars
 immutable
 indefinite-observable
 inversify


### PR DESCRIPTION
Handlebars ships its own types since version 4.1.0