### PR TITLE
Add repo directory key to published package.json

### DIFF
--- a/src/lib/package-generator.ts
+++ b/src/lib/package-generator.ts
@@ -70,6 +70,7 @@ function createPackageJSON(typing: TypingsData, version: string, packages: AllPa
         repository: {
             type: "git",
             url: `${definitelyTypedURL}.git`,
+            directory: `types/${typing.name}`,
         },
         scripts: {},
         dependencies: getDependencies(typing.packageJsonDependencies, typing, packages),


### PR DESCRIPTION
This adds support for [npm RFC 10](https://github.com/npm/rfcs/blob/latest/accepted/0010-monorepo-subdirectory-declaration.md) as defined in [this PR](https://github.com/npm/rfcs/pull/19).