### PR TITLE
Add 'scroll-into-view-if-needed' to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -84,6 +84,7 @@ rollup
 rxjs
 should
 smooth-scrollbar
+scroll-into-view-if-needed
 source-map
 styled-components
 sw-toolbox


### PR DESCRIPTION
This will allow typings to be added to [DefinitelyTyped](https://github.com/jonathanly/DefinitelyTyped) for [icd2k3/react-scroll-into-view-if-needed](https://github.com/icd2k3/react-scroll-into-view-if-needed).

Linking PR from DefinitelyTyped
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33143