### PR TITLE
Specify directory within DefinitelyTyped repo in repository object

### DIFF
--- a/src/lib/package-generator.ts
+++ b/src/lib/package-generator.ts
@@ -70,6 +70,7 @@ function createPackageJSON(typing: TypingsData, version: string, packages: AllPa
         repository: {
             type: "git",
             url: `${definitelyTypedURL}.git`,
+            directory: `types/${typing.name}`,
         },
         scripts: {},
         dependencies: getDependencies(typing.packageJsonDependencies, typing, packages),


### PR DESCRIPTION
Currently, it's hard for automated tools to find the relevant package within the `DefinitelyTyped` monorepo when constructing commits diffs etc.

I worked with the npm team to add a standard for declaring the directory within a repository that a package lives in. The accepted RFC is [here](https://github.com/npm/rfcs/pull/19), and the new guidance was accepted into npm's docs [here](https://github.com/npm/cli/pull/140).

This PR adds the recommended `directory` attribute to the repository specification for each package. It will allow tools like Dependabot to show only the commits that are relevant to a particular packages when creating PRs.