### PR TITLE
Use npm version of dtslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1621,11 +1621,11 @@
       }
     },
     "dts-critic": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/dts-critic/-/dts-critic-1.0.2.tgz",
-      "integrity": "sha512-5grixZ7BUFDx6yGnYTO9HWco6R9Htq+NVP9MPiG96ijdqQQWky70uNS4PlTxEqZsXZ1owrvTwsFLCU+MI+aN4g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dts-critic/-/dts-critic-1.0.3.tgz",
+      "integrity": "sha512-lMU1Lwvzq0dxIj9tNIBA15yYTXNFO2l4zdbiBWhhkW/VAo7h5hlTBIDHYVr6XhhRNkWsd5RCsisVwFJOIOU5IA==",
       "requires": {
-        "definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
+        "definitelytyped-header-parser": "^1.0.0",
         "request-promise-native": "^1.0.5",
         "yargs": "^12.0.5"
       },
@@ -1660,14 +1660,6 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
-          }
-        },
-        "definitelytyped-header-parser": {
-          "version": "github:Microsoft/definitelytyped-header-parser#d957ad0bb2f4ecb60ac04f734e0b38fbc8e70b8a",
-          "from": "github:Microsoft/definitelytyped-header-parser#production",
-          "requires": {
-            "@types/parsimmon": "^1.3.0",
-            "parsimmon": "^1.2.0"
           }
         },
         "execa": {
@@ -1816,10 +1808,11 @@
       }
     },
     "dtslint": {
-      "version": "github:Microsoft/dtslint#62662cf6372c05048774594e213bfa489414e07a",
-      "from": "github:Microsoft/dtslint#production",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-0.4.4.tgz",
+      "integrity": "sha512-JWqvhah6Cnqx1EvI9L8zNwFk9dE4mJJXgHju/FVKlcVeMAdTUyJ0Q20G3D7vp3D5o5qfyMz76dzkzqZ8CaHtgg==",
       "requires": {
-        "definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
+        "definitelytyped-header-parser": "^1.0.1",
         "dts-critic": "^1.0.1",
         "fs-extra": "^6.0.1",
         "request": "^2.88.0",
@@ -1844,14 +1837,6 @@
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
-          }
-        },
-        "definitelytyped-header-parser": {
-          "version": "github:Microsoft/definitelytyped-header-parser#d957ad0bb2f4ecb60ac04f734e0b38fbc8e70b8a",
-          "from": "github:Microsoft/definitelytyped-header-parser#production",
-          "requires": {
-            "@types/parsimmon": "^1.3.0",
-            "parsimmon": "^1.2.0"
           }
         },
         "fs-extra": {
@@ -1890,11 +1875,6 @@
             "tslib": "^1.8.0",
             "tsutils": "^2.27.2"
           }
-        },
-        "typescript": {
-          "version": "3.4.0-dev.20190215",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.0-dev.20190215.tgz",
-          "integrity": "sha512-lGyWJG54e6X/TAJ3oMwNIoK23aeUuNYyaWDQWWVQdP5FD1qQ7FugkGF6ebqmFijeB5OhCR11kfP+Z7FvV7nFSg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "azure-storage": "^2.0.0",
     "charm": "^1.0.2",
     "definitelytyped-header-parser": "^1.0.1",
-    "dtslint": "github:Microsoft/dtslint#production",
+    "dtslint": "^0.4.4",
     "fs-extra": "4.0.0",
     "fstream": "^1.0.10",
     "longjohn": "^0.2.11",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "azure-storage": "^2.0.0",
     "charm": "^1.0.2",
     "definitelytyped-header-parser": "^1.0.1",
-    "dtslint": "^0.4.4",
+    "dtslint": "latest",
     "fs-extra": "4.0.0",
     "fstream": "^1.0.10",
     "longjohn": "^0.2.11",


### PR DESCRIPTION
Now that we will start shipping dtslint from npm instead of the production branch on github.