### PR TITLE
[chokidar] Add chokidar to the dependency list

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -27,6 +27,7 @@ axios
 bignumber.js
 broadcast-channel
 chalk
+chokidar
 cordova-plugin-camera
 cordova-plugin-file
 cordova-plugin-file-transfer


### PR DESCRIPTION
Add `chokidar` to the dependency list so that it can be included as a dependency for other types in the DefinitelyTyped repository.

It's necessary to add to this list so that the `@types/chokidar` package can be removed. 

See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33359 for more context.