### PR TITLE
Add 'three' to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -91,6 +91,7 @@ source-map
 styled-components
 sw-toolbox
 terser
+three
 tslint
 tweetnacl
 typescript


### PR DESCRIPTION
Add `three` to the dependency list so that it can be included as a dependency for other types in the DefinitelyTyped repository.

It's necessary to add to this list so that the `@types/three` package can be removed.

See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33477 for more context.