### PR TITLE
Check deprecated package dependents

### DIFF
--- a/src/get-definitely-typed.test.ts
+++ b/src/get-definitely-typed.test.ts
@@ -1,12 +1,8 @@
 import { Dir, FS, getDefinitelyTyped, InMemoryDT } from "./get-definitely-typed";
 import { Options } from "./lib/common";
 import { loggerWithErrors } from "./util/logging";
+import { testo } from "./util/util";
 
-function testo(o: { [s: string]: () => void }) {
-    for (const k in o) {
-        test(k, o[k], 10_000);
-    }
-}
 testo({
     async downloadDefinitelyTyped() {
         const dt = await getDefinitelyTyped(Options.azure, loggerWithErrors()[0]);

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -109,12 +109,12 @@ export class AllPackages {
 
     /** Returns all of the dependences *that have typings*, ignoring others. */
     *dependencyTypings(pkg: TypingsData): Iterable<TypingsData> {
-        if (pkg.name === 'alt') {
-            console.log('why not alt?')
-            console.log(pkg.dependencies)
-            console.log('this.data has', this.data.get('alt')!.getLatest())
-        }
         for (const { name, majorVersion } of pkg.dependencies) {
+
+            if (pkg.name === 'alt') {
+                console.log('why not alt at ', name, majorVersion)
+                console.log('this.data has', this.data.get('react'))
+            }
             const versions = this.data.get(getMangledNameForScopedPackage(name));
             if (versions) {
                 yield versions.get(majorVersion);

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -109,6 +109,11 @@ export class AllPackages {
 
     /** Returns all of the dependences *that have typings*, ignoring others. */
     *dependencyTypings(pkg: TypingsData): Iterable<TypingsData> {
+        if (pkg.name === 'alt') {
+            console.log('why not alt?')
+            console.log(pkg.dependencies)
+            console.log('this.data has', this.data.get('alt')!.getLatest())
+        }
         for (const { name, majorVersion } of pkg.dependencies) {
             const versions = this.data.get(getMangledNameForScopedPackage(name));
             if (versions) {

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -110,11 +110,6 @@ export class AllPackages {
     /** Returns all of the dependences *that have typings*, ignoring others. */
     *dependencyTypings(pkg: TypingsData): Iterable<TypingsData> {
         for (const { name, majorVersion } of pkg.dependencies) {
-
-            if (pkg.name === 'alt') {
-                console.log('why not alt at ', name, majorVersion)
-                console.log('this.data has', this.data.get('react'))
-            }
             const versions = this.data.get(getMangledNameForScopedPackage(name));
             if (versions) {
                 yield versions.get(majorVersion);
@@ -136,7 +131,7 @@ export class AllPackages {
 }
 
 // Same as the function in moduleNameResolver.ts in typescript
-export function getMangledNameForScopedPackage(packageName: string): string {
+function getMangledNameForScopedPackage(packageName: string): string {
     if (packageName.startsWith("@")) {
         const replaceSlash = packageName.replace("/", "__");
         if (replaceSlash !== packageName) {

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -297,7 +297,7 @@ export interface TypingsDataRaw extends BaseRaw {
 
     readonly minTsVersion: TypeScriptVersion;
     /**
-     * List of TS versions that have their own directoreies, and corresponding "typesVersions" in package.json.
+     * List of TS versions that have their own directories, and corresponding "typesVersions" in package.json.
      * Usually empty.
      */
     readonly typesVersions: ReadonlyArray<TypeScriptVersion>;
@@ -431,7 +431,7 @@ export interface PackageId {
     readonly majorVersion: DependencyVersion;
 }
 
-interface TypesDataFile {
+export interface TypesDataFile {
     readonly [packageName: string]: TypingsVersionsRaw;
 }
 function readTypesDataFile(): Promise<TypesDataFile> {

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -80,7 +80,7 @@ export class AllPackages {
     getTypingsData(id: PackageId): TypingsData {
         const pkg = this.tryGetTypingsData(id);
         if (!pkg) {
-            throw new Error(`No typings available for ${id}`);
+            throw new Error(`No typings available for ${JSON.stringify(id)}`);
         }
         return pkg;
     }
@@ -136,7 +136,7 @@ export class AllPackages {
 }
 
 // Same as the function in moduleNameResolver.ts in typescript
-function getMangledNameForScopedPackage(packageName: string): string {
+export function getMangledNameForScopedPackage(packageName: string): string {
     if (packageName.startsWith("@")) {
         const replaceSlash = packageName.replace("/", "__");
         if (replaceSlash !== packageName) {

--- a/src/parse-definitions.test.ts
+++ b/src/parse-definitions.test.ts
@@ -1,13 +1,8 @@
 import parseDefinitions from "./parse-definitions";
-import { Dir, getDefinitelyTyped, InMemoryDT } from "./get-definitely-typed";
-import { Options } from "./lib/common";
+import { Dir, InMemoryDT } from "./get-definitely-typed";
 import { loggerWithErrors } from "./util/logging";
+import { testo } from "./util/util";
 
-function testo(o: { [s: string]: () => void }) {
-    for (const k in o) {
-        test(k, o[k], 100_000);
-    }
-}
 function createMockDT() {
     const root = new Dir(undefined);
     root.set("notNeededPackages.json", `{
@@ -67,19 +62,19 @@ console.log(jQuery);
     return new InMemoryDT(root, "DefinitelyTyped");
 }
 testo({
-    async parseDefinitions() {
-        const log = loggerWithErrors()[0]
-        // TODO: A mocked DT would be really nice here
-        const dt = await getDefinitelyTyped(Options.defaults, log);
-        const defs = await parseDefinitions(dt, undefined, log)
-        expect(defs.allNotNeeded().length).toBeGreaterThan(0)
-        expect(defs.allTypings().length).toBeGreaterThan(5000)
-        const j = defs.tryGetLatestVersion("jquery")
-        expect(j).toBeDefined()
-        expect(j!.fullNpmName).toContain("types")
-        expect(j!.fullNpmName).toContain("jquery")
-        expect(defs.allPackages().length).toEqual(defs.allTypings().length + defs.allNotNeeded().length)
-    },
+    // async parseDefinitions() {
+    //     const log = loggerWithErrors()[0]
+    //     // TODO: A mocked DT would be really nice here
+    //     const dt = await getDefinitelyTyped(Options.defaults, log);
+    //     const defs = await parseDefinitions(dt, undefined, log)
+    //     expect(defs.allNotNeeded().length).toBeGreaterThan(0)
+    //     expect(defs.allTypings().length).toBeGreaterThan(5000)
+    //     const j = defs.tryGetLatestVersion("jquery")
+    //     expect(j).toBeDefined()
+    //     expect(j!.fullNpmName).toContain("types")
+    //     expect(j!.fullNpmName).toContain("jquery")
+    //     expect(defs.allPackages().length).toEqual(defs.allTypings().length + defs.allNotNeeded().length)
+    // },
     async mockParse() {
         const log = loggerWithErrors()[0];
         const defs = await parseDefinitions(createMockDT(), undefined, log);

--- a/src/parse-definitions.test.ts
+++ b/src/parse-definitions.test.ts
@@ -64,7 +64,6 @@ console.log(jQuery);
 testo({
     // async parseDefinitions() {
     //     const log = loggerWithErrors()[0]
-    //     // TODO: A mocked DT would be really nice here
     //     const dt = await getDefinitelyTyped(Options.defaults, log);
     //     const defs = await parseDefinitions(dt, undefined, log)
     //     expect(defs.allNotNeeded().length).toBeGreaterThan(0)

--- a/src/tester/get-affected-packages.test.ts
+++ b/src/tester/get-affected-packages.test.ts
@@ -1,125 +1,56 @@
 import { testo } from "../util/util";
-import { AllPackages, License, NotNeededPackage, TypesDataFile } from "../lib/packages";
+import { AllPackages, License, NotNeededPackage, TypesDataFile, TypingsVersionsRaw, PackageId } from "../lib/packages";
 import getAffectedPackages from "./get-affected-packages";
 
-const typesData: TypesDataFile = {
-    jquery: {
+function createTypingsVersionRaw(
+    name: string, dependencies: PackageId[], testDependencies: string[]
+): TypingsVersionsRaw {
+    return {
         "1": {
-            libraryName: "JQuery",
-            typingsPackageName: "jquery",
+            libraryName: name,
+            typingsPackageName: name,
+            dependencies,
+            testDependencies,
             files: ["index.d.ts"],
             libraryMajorVersion: 1,
             libraryMinorVersion: 0,
-            dependencies: [
-                { name: "known", majorVersion: 1 },
-                { name: "most-recent", majorVersion: "*" },
-                { name: "unknown", majorVersion: 1 },
-                { name: "deleted", majorVersion: 15 },
-            ],
-            testDependencies: [
-                "known-test",
-                "unknown-test",
-                "deleted-test"],
             pathMappings: [],
-            contributors: [
-                { name: "Bender", url: "futurama.com", githubUsername: "bender" },
-                { name: "Fry", url: "futurama.com", githubUsername: "stephen_fry" },
-                { name: "Leela", url: "futurama.com", githubUsername: "cyclopsian" },
-                { name: "Dr John Zoidberg", url: "futurama.com", githubUsername: "zoidberg" },
-            ],
+            contributors: [{ name: "Bender", url: "futurama.com", githubUsername: "bender" },],
             minTsVersion: "2.3",
             typesVersions: [],
             license: License.MIT,
             packageJsonDependencies: [],
             contentHash: "11111111111111",
-            projectName: "jquery.com",
-            globals: ["jquery", "JQuery", "$"],
-            declaredModules: ["jquery"],
+            projectName: "zombo.com",
+            globals: [],
+            declaredModules: [],
         },
-    },
-    known: {
-        "1": {
-            libraryName: "A known package",
-            typingsPackageName: "known",
-            files: ["index.d.ts"],
-            libraryMajorVersion: 1,
-            libraryMinorVersion: 0,
-            dependencies: [],
-            testDependencies: [],
-            pathMappings: [],
-            contributors: [
-                { name: "Fry", url: "futurama.com", githubUsername: "stephen_fry" },
-            ],
-            minTsVersion: "2.3",
-            typesVersions: [],
-            license: License.MIT,
-            packageJsonDependencies: [],
-            contentHash: "22222222222222",
-            projectName: "",
-            globals: [],
-            declaredModules: [],
-        }
-    },
-    "known-test": {
-        "1": {
-            libraryName: "A known package, used for most-recent version testing",
-            typingsPackageName: "known-test",
-            files: ["index.d.ts"],
-            libraryMajorVersion: 1,
-            libraryMinorVersion: 0,
-            dependencies: [],
-            testDependencies: [],
-            pathMappings: [],
-            contributors: [
-                { name: "Leela", url: "futurama.com", githubUsername: "leela" },
-            ],
-            minTsVersion: "2.3",
-            typesVersions: [],
-            license: License.MIT,
-            packageJsonDependencies: [],
-            contentHash: "4444444444444444",
-            projectName: "",
-            globals: [],
-            declaredModules: [],
-        }
-    },
-    "most-recent": {
-        "2": {
-            libraryName: "A known package, used for most-recent version testing",
-            typingsPackageName: "most-recent",
-            files: ["index.d.ts"],
-            libraryMajorVersion: 1,
-            libraryMinorVersion: 0,
-            dependencies: [],
-            testDependencies: [],
-            pathMappings: [],
-            contributors: [
-                { name: "Dr John Zoidberg", url: "futurama.com", githubUsername: "zoidberg" },
-            ],
-            minTsVersion: "2.3",
-            typesVersions: [],
-            license: License.MIT,
-            packageJsonDependencies: [],
-            contentHash: "333333333333333",
-            projectName: "",
-            globals: [],
-            declaredModules: [],
-        }
-    },
+    }
+}
+const typesData: TypesDataFile = {
+    jquery: createTypingsVersionRaw("jquery", [], []),
+    known: createTypingsVersionRaw("known", [{ name: "jquery", majorVersion: 1 }], []),
+    "known-test": createTypingsVersionRaw("known-test", [], ["jquery"]),
+    "most-recent": createTypingsVersionRaw("most-recent", [{ name: "jquery", majorVersion: "*" }], []),
+    unknown: createTypingsVersionRaw("unknown", [{ name: "COMPLETELY-UNKNOWN", majorVersion: 1 }], []),
+    "unknown-test": createTypingsVersionRaw("unknown-test", [], ["WAT"]),
 };
 
+const notNeeded = [
+    new NotNeededPackage({ typingsPackageName: "jest", libraryName: "jest", asOfVersion: "100.0.0", sourceRepoURL: "jest.com" })
+];
+const allPackages = AllPackages.from(typesData, notNeeded);
+
 testo({
-    simpleDependency() {
-        const packages = [{ name: "jquery", majorVersion: 1 }]
-        const notNeeded = [
-            new NotNeededPackage({ typingsPackageName: "jest", libraryName: "jest", asOfVersion: "100.0.0", sourceRepoURL: "jest.com" })
-        ];
-        const allPackages = AllPackages.from(
-            typesData,
-            notNeeded
-        );
-        const affected = getAffectedPackages(allPackages, packages);
+    updatedPackage() {
+        const affected = getAffectedPackages(allPackages, [{ name: "jquery", majorVersion: 1 }]);
         expect(affected.changedPackages.length).toEqual(1);
+        expect((affected.changedPackages[0] as any).data).toEqual(typesData.jquery[1]);
         expect(affected.dependentPackages.length).toEqual(3);
+    },
+    deletedPackage() {
+        const affected = getAffectedPackages(allPackages, [{ name: "WAT", majorVersion: "*" }]);
+        expect(affected.changedPackages.length).toEqual(0);
+        expect(affected.dependentPackages.length).toEqual(1);
     }
 })

--- a/src/tester/get-affected-packages.test.ts
+++ b/src/tester/get-affected-packages.test.ts
@@ -1,0 +1,125 @@
+import { testo } from "../util/util";
+import { AllPackages, License, NotNeededPackage, TypesDataFile } from "../lib/packages";
+import getAffectedPackages from "./get-affected-packages";
+
+const typesData: TypesDataFile = {
+    jquery: {
+        "1": {
+            libraryName: "JQuery",
+            typingsPackageName: "jquery",
+            files: ["index.d.ts"],
+            libraryMajorVersion: 1,
+            libraryMinorVersion: 0,
+            dependencies: [
+                { name: "known", majorVersion: 1 },
+                { name: "most-recent", majorVersion: "*" },
+                { name: "unknown", majorVersion: 1 },
+                { name: "deleted", majorVersion: 15 },
+            ],
+            testDependencies: [
+                "known-test",
+                "unknown-test",
+                "deleted-test"],
+            pathMappings: [],
+            contributors: [
+                { name: "Bender", url: "futurama.com", githubUsername: "bender" },
+                { name: "Fry", url: "futurama.com", githubUsername: "stephen_fry" },
+                { name: "Leela", url: "futurama.com", githubUsername: "cyclopsian" },
+                { name: "Dr John Zoidberg", url: "futurama.com", githubUsername: "zoidberg" },
+            ],
+            minTsVersion: "2.3",
+            typesVersions: [],
+            license: License.MIT,
+            packageJsonDependencies: [],
+            contentHash: "11111111111111",
+            projectName: "jquery.com",
+            globals: ["jquery", "JQuery", "$"],
+            declaredModules: ["jquery"],
+        },
+    },
+    known: {
+        "1": {
+            libraryName: "A known package",
+            typingsPackageName: "known",
+            files: ["index.d.ts"],
+            libraryMajorVersion: 1,
+            libraryMinorVersion: 0,
+            dependencies: [],
+            testDependencies: [],
+            pathMappings: [],
+            contributors: [
+                { name: "Fry", url: "futurama.com", githubUsername: "stephen_fry" },
+            ],
+            minTsVersion: "2.3",
+            typesVersions: [],
+            license: License.MIT,
+            packageJsonDependencies: [],
+            contentHash: "22222222222222",
+            projectName: "",
+            globals: [],
+            declaredModules: [],
+        }
+    },
+    "known-test": {
+        "1": {
+            libraryName: "A known package, used for most-recent version testing",
+            typingsPackageName: "known-test",
+            files: ["index.d.ts"],
+            libraryMajorVersion: 1,
+            libraryMinorVersion: 0,
+            dependencies: [],
+            testDependencies: [],
+            pathMappings: [],
+            contributors: [
+                { name: "Leela", url: "futurama.com", githubUsername: "leela" },
+            ],
+            minTsVersion: "2.3",
+            typesVersions: [],
+            license: License.MIT,
+            packageJsonDependencies: [],
+            contentHash: "4444444444444444",
+            projectName: "",
+            globals: [],
+            declaredModules: [],
+        }
+    },
+    "most-recent": {
+        "2": {
+            libraryName: "A known package, used for most-recent version testing",
+            typingsPackageName: "most-recent",
+            files: ["index.d.ts"],
+            libraryMajorVersion: 1,
+            libraryMinorVersion: 0,
+            dependencies: [],
+            testDependencies: [],
+            pathMappings: [],
+            contributors: [
+                { name: "Dr John Zoidberg", url: "futurama.com", githubUsername: "zoidberg" },
+            ],
+            minTsVersion: "2.3",
+            typesVersions: [],
+            license: License.MIT,
+            packageJsonDependencies: [],
+            contentHash: "333333333333333",
+            projectName: "",
+            globals: [],
+            declaredModules: [],
+        }
+    },
+};
+
+testo({
+    simpleDependency() {
+        const packages = [{ name: "jquery", majorVersion: 1 }]
+        const notNeeded = [
+            new NotNeededPackage({ typingsPackageName: "jest", libraryName: "jest", asOfVersion: "100.0.0", sourceRepoURL: "jest.com" })
+        ];
+        const allPackages = AllPackages.from(
+            typesData,
+            notNeeded
+        );
+        const affected = getAffectedPackages(allPackages, packages);
+        expect(affected.changedPackages.length).toEqual(1);
+        expect(affected.dependentPackages.length).toEqual(3);
+    }
+})

--- a/src/tester/get-affected-packages.ts
+++ b/src/tester/get-affected-packages.ts
@@ -1,7 +1,7 @@
 import { getDefinitelyTyped } from "../get-definitely-typed";
 import { Options, TesterOptions } from "../lib/common";
 import { parseMajorVersionFromDirectoryName } from "../lib/definition-parser";
-import { AllPackages, PackageBase, TypingsData, PackageId, DependencyVersion } from "../lib/packages";
+import { AllPackages, PackageBase, TypingsData, PackageId, DependencyVersion, getMangledNameForScopedPackage } from "../lib/packages";
 import { sourceBranch, typesDirectoryName } from "../lib/settings";
 import { consoleLogger, Logger, loggerWithErrors } from "../util/logging";
 import { execAndThrowErrors, flatMap, logUncaughtErrors, mapDefined, mapIter, sort } from "../util/util";
@@ -24,21 +24,11 @@ export interface Affected {
 
 /** Gets all packages that have changed on this branch, plus all packages affected by the change. */
 export default async function getAffectedPackages(allPackages: AllPackages, log: Logger, definitelyTypedPath: string): Promise<Affected> {
-    const revs = getReverseDependencies(allPackages);
-    const changedPackageIds = Array.from(await gitChanges(log, definitelyTypedPath));
+    const resolved = (await gitChanges(log, definitelyTypedPath)).map(id => allPackages.tryResolve(id));
     // If a package doesn't exist, that's because it was deleted.
-    const changedPackages = mapDefined(changedPackageIds, (id =>
-        id.majorVersion === "*" ? allPackages.tryGetLatestVersion(id.name) : allPackages.tryGetTypingsData(id)
-    ));
-    const deletedPackages = mapDefined(changedPackageIds, (id => {
-        const res = id.majorVersion === "*" ? allPackages.tryGetLatestVersion(id.name) : allPackages.tryGetTypingsData(id)
-        return res ? undefined : id;
-    }));
-    const revdels = getReverseDependenciesByName(allPackages, deletedPackages);
-    const dependentPackages =[
-        ...collectDependers(changedPackages, revs, t => t),
-        ...collectDependers(deletedPackages, revdels, p => allPackages.getTypingsData(p))];
-    return { changedPackages, dependentPackages };
+    const changed = mapDefined(resolved, id => allPackages.tryGetTypingsData(id));
+    const dependent = mapIter(collectDependers(resolved, getReverseDependencies(allPackages, resolved)), p => allPackages.getTypingsData(p));
+    return { changedPackages: changed, dependentPackages: sortPackages(dependent) };
 }
 
 /** Every package name in the original list, plus their dependencies (incl. dependencies' dependencies). */
@@ -47,13 +37,13 @@ export function allDependencies(allPackages: AllPackages, packages: Iterable<Typ
 }
 
 /** Collect all packages that depend on changed packages, and all that depend on those, etc. */
-function collectDependers<T>(changedPackages: T[], reverseDependencies: Map<T, Set<T>>, convert: (t: T) => TypingsData): TypingsData[] {
+function collectDependers(changedPackages: PackageId[], reverseDependencies: Map<PackageId, Set<PackageId>>): Set<PackageId> {
     const dependers = transitiveClosure(changedPackages, pkg => reverseDependencies.get(pkg) || []);
     // Don't include the original changed packages, just their dependers
     for (const original of changedPackages) {
         dependers.delete(original);
     }
-    return sortPackages(mapIter(dependers, convert));
+    return dependers;
 }
 
 function sortPackages(packages: Iterable<TypingsData>): TypingsData[] {
@@ -86,36 +76,28 @@ function transitiveClosure<T>(initialItems: Iterable<T>, getRelatedItems: (item:
 }
 
 /** Generate a map from a package to packages that depend on it. */
-function getReverseDependencies(allPackages: AllPackages): Map<TypingsData, Set<TypingsData>> {
-    const map = new Map<TypingsData, Set<TypingsData>>();
-    for (const typing of allPackages.allTypings()) {
-        map.set(typing, new Set());
+function getReverseDependencies(allPackages: AllPackages, changedPackages: PackageId[]): Map<PackageId, Set<PackageId>> {
+   const map = new Map<string, [PackageId, Set<PackageId>]>();
+     for (const changed of changedPackages) {
+         map.set(packageIdToKey(changed), [changed, new Set()]);
     }
-
     for (const typing of allPackages.allTypings()) {
-        for (const dependency of allPackages.allDependencyTypings(typing)) {
-            map.get(dependency)!.add(typing);
+        if (!map.has(packageIdToKey(typing.id))) {
+            map.set(packageIdToKey(typing.id), [typing.id, new Set()]);
         }
-    }
-
-    return map;
-}
-
-/** Generate a map from a package to packages that depend on it. */
-function getReverseDependenciesByName(allPackages: AllPackages, deletedPackages: PackageId[]): Map<PackageId, Set<PackageId>> {
-    const map = new Map<string, [PackageId, Set<PackageId>]>();
-    for (const deleted of deletedPackages) {
-        map.set(packageIdToKey(deleted), [deleted, new Set()]);
     }
     for (const typing of allPackages.allTypings()) {
         for (const dependency of typing.dependencies) {
-            if (map.has(packageIdToKey(dependency))) {
-                map.get(packageIdToKey(dependency))![1].add({ name: typing.name, majorVersion: typing.major });
+            const dependencies = map.get(packageIdToKey(allPackages.tryResolve(dependency)))
+            if (dependencies) {
+                dependencies[1].add(typing.id);
             }
         }
         for (const dependencyName of typing.testDependencies) {
-            if (map.has(packageIdToKey({ name: dependencyName, majorVersion: "*"}))) {
-                map.get(packageIdToKey({ name: dependencyName, majorVersion: "*" }))![1].add({ name: typing.name, majorVersion: typing.major });
+            const latest = { name: dependencyName, majorVersion: "*" } as PackageId;
+            const dependencies = map.get(packageIdToKey(allPackages.tryResolve(latest)));
+            if (dependencies) {
+                dependencies[1].add(typing.id);
             }
         }
     }
@@ -123,11 +105,11 @@ function getReverseDependenciesByName(allPackages: AllPackages, deletedPackages:
 }
 
 function packageIdToKey(pkg: PackageId): string {
-    return pkg.name + "/v" + pkg.majorVersion;
+    return getMangledNameForScopedPackage(pkg.name) + "/v" + pkg.majorVersion;
 }
 
 /** Returns all immediate subdirectories of the root directory that have changed. */
-async function gitChanges(log: Logger, definitelyTypedPath: string): Promise<Iterable<PackageId>> {
+async function gitChanges(log: Logger, definitelyTypedPath: string): Promise<Array<PackageId>> {
     const changedPackages = new Map<string, Set<DependencyVersion>>();
 
     for (const fileName of await gitDiff(log, definitelyTypedPath)) {
@@ -142,8 +124,8 @@ async function gitChanges(log: Logger, definitelyTypedPath: string): Promise<Ite
         }
     }
 
-    return flatMap(changedPackages, ([name, versions]) =>
-        mapIter(versions, majorVersion => ({ name, majorVersion })));
+    return Array.from(flatMap(changedPackages, ([name, versions]) =>
+        mapIter(versions, majorVersion => ({ name, majorVersion }))));
 }
 
 /*

--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -43,10 +43,10 @@ export default async function runTests(
     selection: "all" | "affected" | RegExp,
 ): Promise<void> {
     const allPackages = await AllPackages.read(dt);
-    const { changedPackages, dependentPackages }: Affected = selection === "all"
-        ? { changedPackages: allPackages.allTypings(), dependentPackages: [] }
-        : selection === "affected"
-        ? await getAffectedPackages(allPackages, consoleLogger.info, definitelyTypedPath)
+    console.log("!!!!!!!!!!!!!!!!!!!!!!" + selection)
+    const { changedPackages, dependentPackages }: Affected =
+        selection === "all" ? { changedPackages: allPackages.allTypings(), dependentPackages: [] } :
+        selection === "affected" ? await getAffectedPackages(allPackages, consoleLogger.info, definitelyTypedPath)
         : { changedPackages: allPackages.allTypings().filter(t => selection.test(t.name)), dependentPackages: [] };
 
     console.log(`Testing ${changedPackages.length} changed packages: ${changedPackages.map(t => t.desc)}`);

--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -43,7 +43,6 @@ export default async function runTests(
     selection: "all" | "affected" | RegExp,
 ): Promise<void> {
     const allPackages = await AllPackages.read(dt);
-    console.log("!!!!!!!!!!!!!!!!!!!!!!" + selection)
     const { changedPackages, dependentPackages }: Affected =
         selection === "all" ? { changedPackages: allPackages.allTypings(), dependentPackages: [] } :
         selection === "affected" ? await getAffectedPackages(allPackages, consoleLogger.info, definitelyTypedPath)

--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -9,7 +9,7 @@ import { npmInstallFlags } from "../util/io";
 import { consoleLogger, LoggerWithErrors, loggerWithErrors } from "../util/logging";
 import { exec, execAndThrowErrors, joinPaths, logUncaughtErrors, nAtATime, numberOfOsProcesses, runWithListeningChildProcesses } from "../util/util";
 
-import getAffectedPackages, { Affected, allDependencies } from "./get-affected-packages";
+import getAffectedPackages, { Affected, gitChanges, allDependencies } from "./get-affected-packages";
 
 if (!module.parent) {
     const selection = yargs.argv.all ? "all" : yargs.argv._[0] ? new RegExp(yargs.argv._[0]) : "affected";
@@ -45,7 +45,7 @@ export default async function runTests(
     const allPackages = await AllPackages.read(dt);
     const { changedPackages, dependentPackages }: Affected =
         selection === "all" ? { changedPackages: allPackages.allTypings(), dependentPackages: [] } :
-        selection === "affected" ? await getAffectedPackages(allPackages, consoleLogger.info, definitelyTypedPath)
+        selection === "affected" ? await getAffectedPackages(allPackages, await gitChanges(consoleLogger.info, definitelyTypedPath))
         : { changedPackages: allPackages.allTypings().filter(t => selection.test(t.name)), dependentPackages: [] };
 
     console.log(`Testing ${changedPackages.length} changed packages: ${changedPackages.map(t => t.desc)}`);

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -455,3 +455,9 @@ export function assertSorted<T>(a: ReadonlyArray<T>, cb: (t: T) => string = (t: 
     }
     return a;
 }
+
+export function testo(o: { [s: string]: () => void }) {
+    for (const k in o) {
+        test(k, o[k], 100_000);
+    }
+}

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -450,7 +450,7 @@ export function assertSorted<T>(a: ReadonlyArray<T>, cb: (t: T) => string = (t: 
     let prev = a[0];
     for (let i = 1; i < a.length; i++) {
         const x = a[i];
-        assert(cb(x) >= cb(prev), `${x} >= ${prev}`);
+        assert(cb(x) >= cb(prev), `${JSON.stringify(x)} >= ${JSON.stringify(prev)}`);
         prev = x;
     }
     return a;


### PR DESCRIPTION
Dependents of removed packages don't show up because the removed packages don't show up in the list of all packages scraped from Definitely Typed. That means, when constructing the dependent map by reversing the dependency map, removed packages don't get dependents.

This PR fixes the map reversal operation. It also cleans up a bit.