### PR TITLE
Add del to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -33,6 +33,7 @@ cordova-plugin-file
 cordova-plugin-file-transfer
 csstype
 decimal.js
+del
 dnd-core
 egg
 electron


### PR DESCRIPTION
I'm removing it from DT because new version include types.

https://github.com/sindresorhus/del/releases/tag/v4.0.0