### PR TITLE
Add @types/three to dependency whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -8,6 +8,7 @@
 @sentry/browser
 @types/firebase
 @types/js-data
+@types/three
 @types/vue
 @types/webdriverio
 @types/winston


### PR DESCRIPTION
Context: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33477#issuecomment-469876773