### PR TITLE
fix: add expect to dependency whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -40,6 +40,7 @@ egg
 electron
 eventemitter2
 eventemitter3
+expect
 fast-glob
 fastify
 flatpickr


### PR DESCRIPTION
It's had types since https://github.com/facebook/jest/pull/7919, released as 24.3.0 earlier today

Needed for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33705