### PR TITLE
Add knex to whitelist.

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -56,6 +56,7 @@ jointjs
 levelup
 localforage
 log4js
+knex
 magic-string
 mali
 meteor-typings


### PR DESCRIPTION
Knex now bundles its own types and is a dep of several other type libs.
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33889