### PR TITLE
Add @types/hoist-non-react-statics to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -7,6 +7,7 @@
 @babel/types
 @sentry/browser
 @types/firebase
+@types/hoist-non-react-statics
 @types/js-data
 @types/three
 @types/vue


### PR DESCRIPTION
_The full context of this change is captured in the `DefinitivelyTyped` thread beginning here: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33690#issuecomment-474043897_

From version `2.2.0` to `3.0.0`, the `hoist-non-react-statics` package defined its own typings. In `3.0.0`, they were removed.

Because package-local typings take precedence over `@types`, it's possible for downstream type dependencies (e.g., `@types/react-redux`) to unintentionally load the older, builtin types if the version of `hoist-non-react-statics` in the consumer resolves within the `2.2.0~3.0.0` range. This wasn't a problem until I added a change to `@types/react-redux` that depends upon a change shipped in `@types/hoist-non-react-statics@3.3.0`.

In order to fix this problem, I need the ability to specify a versionspec for `@types/hoist-non-react-statics` in the `package.json` of `@types/react-redux` (which I've submitted in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33979), and in order to do that, I need `@types/hoist-non-react-statics` to be added to this whitelist.

I've [been advised](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33919#issuecomment-474075210) by @weswigham and @sandersn that this is the correct approach, so I hope you'll consider merging this ASAP so we can unbreak consumers of `@types/react-redux`, which is a very popular package.