### PR TITLE
Deprecation fix part 3

### DIFF
--- a/src/calculate-versions.ts
+++ b/src/calculate-versions.ts
@@ -2,7 +2,7 @@ import assert = require("assert");
 
 import { FS, getDefinitelyTyped } from "./get-definitely-typed";
 import { Options, writeDataFile } from "./lib/common";
-import { CachedNpmInfoClient, UncachedNpmInfoClient, NpmInfoVersion } from "./lib/npm-client";
+import { withNpmCache, CachedNpmInfoClient, UncachedNpmInfoClient, NpmInfoVersion } from "./lib/npm-client";
 import { AllPackages, TypingsData, NotNeededPackage } from "./lib/packages";
 import { ChangedPackages, ChangedPackagesJson, ChangedTypingJson, Semver, versionsFilename } from "./lib/versions";
 import { loggerWithErrors, LoggerWithErrors } from "./util/logging";
@@ -18,7 +18,7 @@ export default async function calculateVersions(
     log: LoggerWithErrors
 ): Promise<ChangedPackages> {
     log.info("=== Calculating versions ===");
-    return CachedNpmInfoClient.with(uncachedClient, async client => {
+    return withNpmCache(uncachedClient, async client => {
         log.info("* Reading packages...");
         const packages = await AllPackages.read(dt);
         return computeAndSaveChangedPackages(packages, log, client);

--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -57,8 +57,8 @@ async function generateTypingPackage(typing: TypingsData, packages: AllPackages,
 
     const packageJson = createPackageJSON(typing, version, packages);
     await writeCommonOutputs(typing, packageJson, createReadme(typing));
-    await Promise.all(typing.files.
-                      map(async file => writeFile(await outputFilePath(typing, file), await packageFS.readFile(file))));
+    await Promise.all(
+        typing.files.map(async file => writeFile(await outputFilePath(typing, file), await packageFS.readFile(file))));
 }
 
 async function generateNotNeededPackage(pkg: NotNeededPackage, client: CachedNpmInfoClient, log: Logger): Promise<void> {

--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -15,7 +15,7 @@ import { assertNever, joinPaths, logUncaughtErrors, sortObjectKeys } from "./uti
 import { makeTypesVersionsForPackageJson } from "definitelytyped-header-parser";
 import { mkdir, mkdirp, readFileSync } from "fs-extra";
 import * as path from "path";
-import { CachedNpmInfoClient, UncachedNpmInfoClient } from "./lib/npm-client";
+import { withNpmCache, CachedNpmInfoClient, UncachedNpmInfoClient } from "./lib/npm-client";
 
 const mitLicense = readFileSync(joinPaths(__dirname, "..", "LICENSE"), "utf-8");
 
@@ -43,7 +43,7 @@ export default async function generatePackages(dt: FS, allPackages: AllPackages,
         log(` * ${pkg.libraryName}`);
     }
     log("## Generating deprecated packages");
-    CachedNpmInfoClient.with(new UncachedNpmInfoClient(), async client => {
+    withNpmCache(new UncachedNpmInfoClient(), async client => {
         for (const pkg of changedPackages.changedNotNeededPackages) {
             log(` * ${pkg.libraryName}`);
             await generateNotNeededPackage(pkg, client, log);

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -65,7 +65,10 @@ export function skipBadPublishes(pkg: NotNeededPackage, client: CachedNpmInfoCli
 
 function findActualLatest(times: Map<string,string>) {
     const actual = best(
-        times, ([_,v], [bestK,bestV]) => (bestK === "modified") ? true : new Date(v) > new Date(bestV));
+        times, ([k,v], [bestK,bestV]) =>
+            (bestK === "modified" || bestK === "created") ? true :
+            (k === "modified" || k === "created") ? false :
+            new Date(v) > new Date(bestV));
     if (!actual) {
         throw new Error("failed to find actual latest");
     }

--- a/src/publish-packages.ts
+++ b/src/publish-packages.ts
@@ -3,7 +3,7 @@ import * as yargs from "yargs";
 import appInsights = require("applicationinsights");
 import { getDefinitelyTyped } from "./get-definitely-typed";
 import { Options } from "./lib/common";
-import { NpmPublishClient, UncachedNpmInfoClient, CachedNpmInfoClient } from "./lib/npm-client";
+import { withNpmCache, NpmPublishClient, UncachedNpmInfoClient } from "./lib/npm-client";
 import { deprecateNotNeededPackage, publishNotNeededPackage, publishTypingsPackage } from "./lib/package-publisher";
 import { AllPackages } from "./lib/packages";
 import { ChangedPackages, readChangedPackages, skipBadPublishes } from "./lib/versions";
@@ -114,7 +114,7 @@ export default async function publishPackages(
         }
     }
 
-    CachedNpmInfoClient.with(new UncachedNpmInfoClient(), async infoClient => {
+    withNpmCache(new UncachedNpmInfoClient(), async infoClient => {
         for (const n of changedPackages.changedNotNeededPackages) {
             await publishNotNeededPackage(client, skipBadPublishes(n, infoClient, log), dry, log);
         }


### PR DESCRIPTION
Three things:

1. Improve logging in npm-client. I'm trying to figure out why the cache isn't acting like it's getting updated.
2. Remove CachedNpmInfoClient class, replaced with a function and an interface.
3. Make findActualLatest skip 'modified' AND 'created', in cases where there was only one version, and its time is identical to 'created'.
