### PR TITLE
Added xmlbuilder to dependencies whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -106,4 +106,5 @@ vue
 vue-router
 vuex
 winston
+xmlbuilder
 zipkin


### PR DESCRIPTION
xmlbuilder has own typings added in 11.0.1:
https://github.com/oozcitak/xmlbuilder-js/commit/cbe15c56fd85bee0d377769f9099654efeff4962