### PR TITLE
Add prom-client to dependency whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -75,6 +75,7 @@ popper.js
 postcss
 preact
 probot
+prom-client
 protobufjs
 protractor
 quill-delta


### PR DESCRIPTION
prom-client provides its own typings