### PR TITLE
Add hoist-non-react-statics to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -50,6 +50,7 @@ google-gax
 graphql-tools
 grpc
 handlebars
+hoist-non-react-statics
 immutable
 indefinite-observable
 inversify


### PR DESCRIPTION
Ref: #595 and DefinitelyTyped/DefinitelyTyped#33690

Some related discussion points from the referenced issues
> From version 2.2.0 to 3.0.0, the hoist-non-react-statics package defined its own typings. In 3.0.0, they were removed.

> Because package-local typings take precedence over @types, it's possible for downstream type dependencies (e.g., @types/react-redux) to unintentionally load the older, builtin types if the version of hoist-non-react-statics in the consumer resolves within the 2.2.0~3.0.0 range. This wasn't a problem until I added a change to @types/react-redux that depends upon a change shipped in @types/hoist-non-react-statics@3.3.0.

This should be merged ASAP for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/34406 to move on