### PR TITLE
dependenciesWhitelist.txt add package cac

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -28,6 +28,7 @@ axe-core
 axios
 bignumber.js
 broadcast-channel
+cac
 chalk
 chokidar
 cordova-plugin-camera


### PR DESCRIPTION
Hi, I'm creating a package type definition: DefinitelyTyped/DefinitelyTyped#34424

And the unit test told me if the package depend on a external package, I should add it to dependenciesWhitelist.txt