### PR TITLE
dependenciesWhitelist.txt add package cac, webpack-chain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
   - master
 
 install:
-  - npm install
+  - npm ci
 
 git:
   depth: 1

--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -28,6 +28,7 @@ axe-core
 axios
 bignumber.js
 broadcast-channel
+cac
 chalk
 chokidar
 cordova-plugin-camera
@@ -106,5 +107,6 @@ typescript
 vue
 vue-router
 vuex
+webpack-chain
 winston
 zipkin


### PR DESCRIPTION
Hi, I'm creating a package type definition: DefinitelyTyped/DefinitelyTyped#34424

And the unit test told me if the package depend on a external package, I should add it to dependenciesWhitelist.txt

Although DefinitelyTyped already has webpack-chain, the type of
webpack-chain official repository is newer.

https://github.com/neutrinojs/webpack-chain/tree/master/types