### PR TITLE
Add sequelize to dependencies whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -94,6 +94,7 @@ redux-thunk
 rollup
 rxjs
 safe-buffer
+sequelize
 should
 smooth-scrollbar
 scroll-into-view-if-needed


### PR DESCRIPTION
[Sequelize](https://github.com/sequelize/sequelize) now ships official typings, so adding to dependencies whitelist, as it is referenced by other type packages.