### PR TITLE
test-runner now shells one node for each dtslint

### DIFF
--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -15,6 +15,7 @@ import { consoleLogger, Logger, LoggerWithErrors, loggerWithErrors } from "../ut
 import { assertDefined, exec, execAndThrowErrors, flatMap, joinPaths, logUncaughtErrors, mapIter, nAtATime, numberOfOsProcesses, runWithListeningChildProcesses } from "../util/util";
 
 import { getAffectedPackages, Affected, allDependencies } from "./get-affected-packages";
+import { dirname } from "path";
 
 if (!module.parent) {
     if (yargs.argv.affected) {
@@ -167,8 +168,8 @@ async function doRunTests(
     if (fold.isTravis()) { console.log(fold.start("tests")); }
     await runWithListeningChildProcesses({
         inputs: packages.map(p => ({ path: p.subDirectoryPath, onlyTestTsNext: !changed.has(p), expectOnly: !changed.has(p) })),
-        commandLineArgs: ["--listen"],
-        workerFile: require.resolve("dtslint"),
+        commandLineArgs: [],
+        workerFile: joinPaths(dirname(require.resolve("types-publisher")), "tester/test-worker.js"),
         nProcesses,
         cwd: typesPath,
         handleOutput(output): void {
@@ -176,7 +177,6 @@ async function doRunTests(
             if (status === "OK") {
                 console.log(`${path} OK`);
             } else {
-                console.error(`${path} failing:`);
                 console.error(status);
                 allFailures.push([path, status]);
             }

--- a/src/tester/test-worker.ts
+++ b/src/tester/test-worker.ts
@@ -1,0 +1,13 @@
+import cp = require("child_process");
+process.on("message", (message: {}) => {
+    const { path, onlyTestTsNext, expectOnly } = message as { path: string, onlyTestTsNext: boolean, expectOnly?: boolean };
+    require.resolve("dtslint")
+    const cmd = `node ${require.resolve("dtslint")} ${onlyTestTsNext ? "--onlyTestTsNext" : ""} ${expectOnly ? "--expectOnly" : ""} ${path}`
+    cp.exec(cmd, { cwd: process.cwd() },
+            err => {
+                if (err)
+                    process.send!({ path, status: err.message })
+                else
+                    process.send!({ path, status: "OK" })
+            });
+});


### PR DESCRIPTION
It uses the new, local test-worker, which just calls cp.exec(node dtslint) for each dtslint, instead of reusing the same dtslint over and over again.

lodash and reactstrap still run out of memory, but they do that for individual calls to dtslint as well. I think multi-Typescript compiles in ExpectRule may need the same out-of-proc treatment.

Edit: No, types/lodash and types/reactstrap also run out of memory when just compiling with ts 3.4.