### PR TITLE
Add scaling crash recovery for types tester

### DIFF
--- a/src/lib/secrets.ts
+++ b/src/lib/secrets.ts
@@ -35,7 +35,7 @@ export enum Secret {
 }
 
 export const allSecrets: Secret[] = mapDefined(Object.keys(Secret), key => {
-    const value = (Secret as { [key: string]: unknown })[key];
+    const value = (Secret as unknown as { [key: string]: unknown })[key];
     return typeof value === "number" ? value : undefined; // tslint:disable-line strict-type-predicates (tslint bug)
 });
 

--- a/src/tester/test-runner.ts
+++ b/src/tester/test-runner.ts
@@ -12,7 +12,7 @@ import { AllPackages, DependencyVersion, PackageId, TypingsData, NotNeededPackag
 import { UncachedNpmInfoClient, NpmInfo } from "../lib/npm-client";
 import { npmInstallFlags } from "../util/io";
 import { consoleLogger, Logger, LoggerWithErrors, loggerWithErrors } from "../util/logging";
-import { assertDefined, exec, execAndThrowErrors, flatMap, joinPaths, logUncaughtErrors, mapIter, nAtATime, numberOfOsProcesses, runWithListeningChildProcesses } from "../util/util";
+import { assertDefined, exec, execAndThrowErrors, flatMap, joinPaths, logUncaughtErrors, mapIter, nAtATime, numberOfOsProcesses, runWithListeningChildProcesses, CrashRecoveryState } from "../util/util";
 
 import { getAffectedPackages, Affected, allDependencies } from "./get-affected-packages";
 
@@ -170,6 +170,8 @@ async function doRunTests(
         commandLineArgs: ["--listen"],
         workerFile: require.resolve("dtslint"),
         nProcesses,
+        crashRecovery: true,
+        crashRecoveryMaxOldSpaceSize: 0, // disable retry with more memory
         cwd: typesPath,
         handleOutput(output): void {
             const { path, status } = output as { path: string, status: string };
@@ -179,6 +181,17 @@ async function doRunTests(
                 console.error(`${path} failing:`);
                 console.error(status);
                 allFailures.push([path, status]);
+            }
+        },
+        handleCrash(input, state) {
+            switch (state) {
+                case CrashRecoveryState.Retry:
+                    console.log(`${input.path} Out of memory: retrying`);
+                    break;
+                case CrashRecoveryState.RetryWithMoreMemory:
+                    console.log(`${input.path} Out of memory: retrying with increased memory (4096M)`);
+                    break;
+                default:
             }
         },
     });


### PR DESCRIPTION
Rather than crashing the types tester when a forked process runs out of memory, the tester will now perform crash recovery using a scaling recovery mechanism:

1. By default, each forked process starts in a *crash recovery state* of `Normal`.
1. If a forked process crashes due to running out of memory and its *crash recovery state* is `Normal`, we will restart the forked process to try again:
    1. For the crashing process, its *crash recovery state* is incremented to `Retry`.
    1. If the test succeeds, the *crash recovery state* is reset to `Normal`.
1. If the forked process crashes while its *crash recovery state* is `Retry`, we will restart the forked process again with the following changes:
    1. For the crashing process, its *crash recovery state* is incremented to `RetryWithMoreMemory`.
    1. The forked process is restarted with `--max_old_space_size=4096`.
    1. If the test succeeds, the *crash recovery state* is reset to `Normal` and the forked process is restarted with the default `--max_old_space_size` settings.
1. If the forked process crashes while its *crash recovery state* is `RetryWithMoreMemory`, we will fall back to crashing the root process (existing behavior).

Whenever the *crash recovery state* of a forked process changes, a message will be written to the log indicating which package caused the crash and the current recovery state.

For example:
```
…
clean-css OK
cli-color OK
cli-progress OK
client-sessions OK
cli-spinner OK
cloneable-readable OK
cls-hooked OK
codependency OK
co-body OK

<--- Last few GCs --->

[22336:000002A80B561640]   397502 ms: Scavenge 1356.3 (1421.6) -> 1355.8 (1422.1) MB, 6.9 / 0.0 ms  (average mu = 0.150, current mu = 0.124) allocation failure
[22336:000002A80B561640]   397515 ms: Scavenge 1356.6 (1422.1) -> 1356.1 (1422.6) MB, 9.1 / 0.0 ms  (average mu = 0.150, current mu = 0.124) allocation failure
[22336:000002A80B561640]   397530 ms: Scavenge 1356.8 (1422.6) -> 1356.3 (1423.1) MB, 11.4 / 0.0 ms  (average mu = 0.150, current mu = 0.124) allocation failure


<--- JS stacktrace --->

==== JS stack trace =========================================

    0: ExitFrame [pc: 00000040451DC6C1]
    1: StubFrame [pc: 00000040451DDC86]
Security context: 0x009783a1e681 <JSObject>
    2: getIntersectionType(aka getIntersectionType) [000002F5E768DC79] [C:\Users\rbuckton\.dts\typescript-installs\2.9\node_modules\typescript\lib\typescript.js:~34423] [pc=0000004047C96D4A](this=0x0316a75826f1 <undefined>,types=0x00089a602c91 <JSArray[2]>,aliasSymbol=0x0316a75826f1 <undefined>,aliasTypeArguments=0x0...

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
 1: 00007FF72420EEE5
 2: 00007FF7241E8CD6
 3: 00007FF7241E96E0
 4: 00007FF724650D3E
 5: 00007FF724650C6F
 6: 00007FF72459C594
 7: 00007FF724592B67
 8: 00007FF7245910DC
 9: 00007FF72459A0B7
10: 00007FF72459A136
11: 00007FF7246BF7B7
12: 00007FF7247987FA
13: 00000040451DC6C1
reactstrap Out of memory: retrying
reactstrap OK
...
```