### PR TITLE
Stop using optional catch binding which is not supported in node < 10

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -538,7 +538,7 @@ export function runWithListeningChildProcesses<In>(
                     try {
                         child.removeAllListeners();
                         child.kill();
-                    } catch {
+                    } catch (e) {
                         // do nothing
                     }
                 }


### PR DESCRIPTION
https://github.com/Microsoft/types-publisher/pull/608 added optional catch binding which is not supported in node < 10. This packages supports node >=6.10.0 According to [package.json](https://github.com/Microsoft/types-publisher/blob/master/package.json#L83), this package supports node >=6.10.0. 

I think we have two options to solve this problem
1. Stop using optional catch binding
2. Change TypeScript build target from esnext https://github.com/Microsoft/types-publisher/blob/master/tsconfig.json#L15

In this PR, I selected the former option because we need to fix quickly broken DefinitelyTyped CI pipeline. ( see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/34973 )
