### PR TITLE
Fix compilation with typescript@next

### DIFF
--- a/src/util/io.ts
+++ b/src/util/io.ts
@@ -62,7 +62,7 @@ export interface FetchOptions {
     readonly hostname: string;
     readonly port?: number;
     readonly path: string;
-    readonly retries?: true | number;
+    readonly retries?: boolean | number;
     readonly body?: string;
     readonly method?: "GET" | "PATCH" | "POST";
     readonly headers?: {};


### PR DESCRIPTION
Fixes

```
src/util/io.ts:83:28 - error TS2367: This condition will always return 'false' since the types 'number | true | undefined' and 'false' have no overlap.

83         const maxRetries = options.retries === false || options.retries === undefined ? 0 : options.retries === true ? 10 : options.retries;
                              ~~~~~~~~~~~~~~~~~~~~~~~~~
```