### PR TITLE
Add loglevel to whitelisted dependencies

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -61,6 +61,7 @@ jointjs
 levelup
 localforage
 log4js
+loglevel
 knex
 magic-string
 mali


### PR DESCRIPTION
Loglevel has just added built-in types (https://github.com/pimterry/loglevel/commit/c54a06fc11f6686b9a250ea5d593a426e1a61978), so needs to be removed from DefinitelyTyped, but `@types/webpack-dev-middleware` depends on these types, and so needs a dependency on this new version.

Corresponding DefinitelyTyped PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/35833