### PR TITLE
Add utility-types to whitelisted dependencies

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -107,6 +107,7 @@ three
 tslint
 tweetnacl
 typescript
+utility-types
 vue
 vue-router
 vuex


### PR DESCRIPTION
Add [utility-types](https://github.com/piotrwitek/utility-types) to whitelisted dependency.

It provides its own typings and is used in DefinitelyTyped PR: [DefinitelyTyped/DefinitelyTyped#35609](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/35609)