### PR TITLE
added cosmiconfig to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -7,6 +7,7 @@
 @babel/types
 @material-ui/core
 @sentry/browser
+@types/cosmiconfig
 @types/firebase
 @types/hoist-non-react-statics
 @types/js-data


### PR DESCRIPTION
postcss-load-config depends on an older version of cosmiconfig so I need this for my postcss-load-config definitions.

I have a PR open for that [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/36053)