### PR TITLE
add jest dependencies to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -5,6 +5,10 @@
 @babel/template
 @babel/traverse
 @babel/types
+@jest/environment
+@jest/fake-timers
+@jest/transform
+@jest/types
 @material-ui/core
 @sentry/browser
 @types/firebase
@@ -57,6 +61,11 @@ hoist-non-react-statics
 immutable
 indefinite-observable
 inversify
+jest-diff
+jest-environment-node
+jest-environment-jsdom
+jest-mock
+jest-snapshot
 jointjs
 levelup
 localforage


### PR DESCRIPTION
Adds jest dependencies to provide external typings for DefinitelyTyped `@types/jest-environment-puppeteer`.

> If this is an external library that provides typings,  please make a pull request to types-publisher adding it to \`dependenciesWhitelist.txt\`.`;
