### PR TITLE
Add commander to whitelisted dependencies

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -33,6 +33,7 @@ broadcast-channel
 cac
 chalk
 chokidar
+commander
 cordova-plugin-camera
 cordova-plugin-file
 cordova-plugin-file-transfer


### PR DESCRIPTION
This adds [`commander`](https://github.com/tj/commander.js/) to the whitelisted dependencies to be able to merge https://github.com/DefinitelyTyped/DefinitelyTyped/pull/36148.