### PR TITLE
Add swagger-parser to whitelisted dependencies

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -102,6 +102,7 @@ scroll-into-view-if-needed
 source-map
 styled-components
 sw-toolbox
+swagger-parser
 terser
 three
 tslint


### PR DESCRIPTION
This adds [`swagger-parser`](https://github.com/APIDevTools/swagger-parser/) to the whitelisted dependencies to be able to merge https://github.com/DefinitelyTyped/DefinitelyTyped/pull/36165.