### PR TITLE
add re-resizable to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -84,6 +84,7 @@ protobufjs
 protractor
 quill-delta
 raven-js
+re-resizable
 react-dnd
 react-native-maps
 react-native-svg


### PR DESCRIPTION
This PR adds [re-resizable](https://github.com/bokuweb/re-resizable) to the whitelist.

Related: DefinitelyTyped/DefinitelyTyped#36184