### PR TITLE
Add multiple Electron projects to whitelisted dependencies

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -5,6 +5,7 @@
 @babel/template
 @babel/traverse
 @babel/types
+@electron/get
 @jest/environment
 @jest/fake-timers
 @jest/transform
@@ -47,6 +48,8 @@ del
 dnd-core
 egg
 electron
+electron-notarize
+electron-osx-sign
 eventemitter2
 eventemitter3
 expect


### PR DESCRIPTION
This PR will add
- [`@electron/get`](https://www.npmjs.com/package/@electron/get)
- [`electron-notarize`](https://www.npmjs.com/package/electron-notarize)
- [`electron-osx-sign`](https://www.npmjs.com/package/electron-osx-sign)

to the whitelisted dependencies to be able to merge https://github.com/DefinitelyTyped/DefinitelyTyped/pull/36441.