### PR TITLE
Add bookshelf to dependenciesWhitelist.txt for use in @types/bookshelf

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -34,6 +34,7 @@ aws-sdk
 axe-core
 axios
 bignumber.js
+bookshelf
 broadcast-channel
 cac
 chalk


### PR DESCRIPTION
I'm going to submit a PR to update @types/bookshelf to depend on [bookshelf](https://github.com/bookshel) rather than knex. This will ensure the types align more easily. 