### PR TITLE
Update dependenciesWhitelist.txt

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -56,6 +56,7 @@ expect
 fast-glob
 fastify
 flatpickr
+form-data
 google-auth-library
 google-gax
 graphql-tools


### PR DESCRIPTION
Add `form-data`.

Removing `@types/form-data`. Must add it here, otherwise other packages, which refers to form-data in DefinitelyTyped, will fail the npm test.