### PR TITLE
Adds lit-element to the dependencies whitelist for use in @types/storybook__polymer

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -74,6 +74,7 @@ jest-mock
 jest-snapshot
 jointjs
 levelup
+lit-element
 localforage
 log4js
 loglevel


### PR DESCRIPTION
I'm going to be submitting a PR for @types/storybook__polymer that requires typedefs created in `lit-element`.