### PR TITLE
Add 'date-fns' dependencies to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -44,6 +44,7 @@ cordova-plugin-camera
 cordova-plugin-file
 cordova-plugin-file-transfer
 csstype
+date-fns
 decimal.js
 del
 dnd-core


### PR DESCRIPTION
Adds `date-fns` dependencies to provide external typings for DefinitelyTyped `@types/react-datepicker`.

> Error: In package.json: Dependency date-fns not in whitelist.
> If you are depending on another `@types` package, do *not* add it to a `package.json`. Path mapping should make the import work.
> If this is an external library that provides typings,  please make a pull request to types-publisher adding it to `dependenciesWhitelist.txt`.