### PR TITLE
add react-autosize-textarea to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -104,6 +104,7 @@ protractor
 quill-delta
 raven-js
 re-resizable
+react-autosize-textarea
 react-dnd
 react-native-maps
 react-native-svg


### PR DESCRIPTION
This PR add [react-autosize-textarea](https://github.com/buildo/react-autosize-textarea) to the whitelist.

Related: DefinitelyTyped/DefinitelyTyped#37006