### PR TITLE
Add 'express-graphql' dependencies to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -55,6 +55,7 @@ electron-osx-sign
 eventemitter2
 eventemitter3
 expect
+express-graphql
 fast-glob
 fastify
 flatpickr


### PR DESCRIPTION
I added TS typings to `express-graphql` and now I'm trying to remove it from DT but as I understand I need to whitelist it first:

> Error: In package.json: Dependency express-graphql not in whitelist.
If you are depending on another `@types` package, do *not* add it to a `package.json`. Path mapping should make the import work.
If this is an external library that provides typings,  please make a pull request to types-publisher adding it to `dependenciesWhitelist.txt`.