### PR TITLE
Add dexie to whitelisted dependencies

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -47,6 +47,7 @@ csstype
 date-fns
 decimal.js
 del
+dexie
 dnd-core
 egg
 electron


### PR DESCRIPTION
This adds [`Dexie`](https://www.npmjs.com/package/dexie) to the whitelisted dependencies to be able to merge https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37160.