### PR TITLE
Add "ts-toolbelt" to the whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -130,6 +130,7 @@ swagger-parser
 terser
 three
 tslint
+ts-toolbelt
 tweetnacl
 typescript
 utility-types


### PR DESCRIPTION
Adds "ts-toolbelt" to the whitelist to bring its external typings to DefinitelyTyped (for ramda & others)