### PR TITLE
Add react-intl to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -108,6 +108,7 @@ raven-js
 re-resizable
 react-autosize-textarea
 react-dnd
+react-intl
 react-native-maps
 react-native-modal
 react-native-svg


### PR DESCRIPTION
since it comes with its own type def & react-intl-redux relies on it