### PR TITLE
Add i18next to whitelist.

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -67,6 +67,7 @@ graphql-tools
 grpc
 handlebars
 hoist-non-react-statics
+i18next
 immutable
 indefinite-observable
 inversify


### PR DESCRIPTION
This is required for https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37433 to use the types bundled with i18next.