### PR TITLE
Add xpath to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -141,4 +141,5 @@ vuex
 webpack-chain
 winston
 xmlbuilder
+xpath
 zipkin


### PR DESCRIPTION
This is required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37484 to use the types bundled with xpath.