### PR TITLE
Content-Encoding header is usually lowercase

### DIFF
--- a/src/lib/azure-container.ts
+++ b/src/lib/azure-container.ts
@@ -73,7 +73,7 @@ export default class BlobWriter {
     private createBlobFromStream(blobName: string, stream: NodeJS.ReadableStream): Promise<void> {
         const options: BlobService.CreateBlobRequestOptions =  {
             contentSettings: {
-                contentEncoding: "GZIP",
+                contentEncoding: "gzip",
                 contentType: "application/json; charset=utf-8",
             },
         };
@@ -88,7 +88,7 @@ export async function readBlob(blobName: string): Promise<string> {
         const req = https.get(url, res => {
             switch (res.statusCode) {
                 case 200:
-                    if (res.headers["content-encoding"] !== "GZIP") {
+                    if (res.headers["content-encoding"] !== "gzip") {
                         reject(new Error(`${url} is not gzipped`));
                     } else {
                         resolve(stringOfStream(unGzip(res), blobName));


### PR DESCRIPTION
I tried downloading, with a script, the JSON file created by `npm run index` but the header content-encoding is set to `GZIP` instead of the usual `gzip`.
I'm not sure if it can be uppercase but the RFC is too much for me ahah; browsers obviously support both but some scripts/packages do not expect uppercase value.

