### PR TITLE
Add @vue/test-utils to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -22,6 +22,7 @@
 @types/wonder-commonlib
 @types/wonder-frp
 @uirouter/angularjs
+@vue/test-utils
 abort-controller
 activex-helpers
 ajv


### PR DESCRIPTION
This will be needed by the types for `@testing-library/vue`.

(I haven't opened a DefinitelyTyped PR yet because I'm waiting on `@testing-library/dom` to be moved there first. You can see testing-library/vue-testing-library#74 if you're interested.)