### PR TITLE
Added winston-transport as a whitelisted dependency for use in my @ty…

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -142,6 +142,7 @@ vue-router
 vuex
 webpack-chain
 winston
+winston-transport
 xmlbuilder
 xpath
 zipkin


### PR DESCRIPTION
Simple update to the dependency whitelist so the my other PR to add @types/datadog-winston can work properly according to the documentation.