### PR TITLE
Log dependent packages in version error case.

### DIFF
--- a/src/tester/get-affected-packages.ts
+++ b/src/tester/get-affected-packages.ts
@@ -4,6 +4,7 @@ import { mapDefined, mapIter, sort } from "../util/util";
 export interface Affected {
     readonly changedPackages: ReadonlyArray<TypingsData>;
     readonly dependentPackages: ReadonlyArray<TypingsData>;
+    allPackages: AllPackages
 }
 
 /** Gets all packages that have changed on this branch, plus all packages affected by the change. */
@@ -12,7 +13,7 @@ export function getAffectedPackages(allPackages: AllPackages, changedPackageIds:
     // If a package doesn't exist, that's because it was deleted.
     const changed = mapDefined(resolved, id => allPackages.tryGetTypingsData(id));
     const dependent = mapIter(collectDependers(resolved, getReverseDependencies(allPackages, resolved)), p => allPackages.getTypingsData(p));
-    return { changedPackages: changed, dependentPackages: sortPackages(dependent) };
+    return { changedPackages: changed, dependentPackages: sortPackages(dependent), allPackages };
 }
 
 /** Every package name in the original list, plus their dependencies (incl. dependencies' dependencies). */

--- a/src/tester/get-affected-packages.ts
+++ b/src/tester/get-affected-packages.ts
@@ -4,7 +4,7 @@ import { mapDefined, mapIter, sort } from "../util/util";
 export interface Affected {
     readonly changedPackages: ReadonlyArray<TypingsData>;
     readonly dependentPackages: ReadonlyArray<TypingsData>;
-    allPackages: AllPackages
+    allPackages: AllPackages;
 }
 
 /** Gets all packages that have changed on this branch, plus all packages affected by the change. */

--- a/src/tester/test.ts
+++ b/src/tester/test.ts
@@ -27,7 +27,7 @@ async function main(options: TesterOptions, nProcesses: number, all: boolean): P
     }
     catch (e) {
         if (!all) {
-            (await getAffectedPackagesFromDiff(dt, options.definitelyTypedPath, "affected")).dependentPackages.map(t => t.desc);
+            await getAffectedPackagesFromDiff(dt, options.definitelyTypedPath, "affected")
         }
 
         throw e;

--- a/src/tester/test.ts
+++ b/src/tester/test.ts
@@ -9,7 +9,7 @@ import parseDefinitions from "../parse-definitions";
 import { loggerWithErrors } from "../util/logging";
 import { logUncaughtErrors } from "../util/util";
 
-import runTests, { parseNProcesses, testerOptions } from "./test-runner";
+import runTests, { parseNProcesses, testerOptions, getAffectedPackagesFromDiff } from "./test-runner";
 
 if (!module.parent) {
     const options = testerOptions(!!yargs.argv.runFromDefinitelyTyped);
@@ -22,6 +22,15 @@ async function main(options: TesterOptions, nProcesses: number, all: boolean): P
     const log = loggerWithErrors()[0];
     const dt = await getDefinitelyTyped(options, log);
     await parseDefinitions(dt, { nProcesses, definitelyTypedPath: options.definitelyTypedPath }, log);
-    await checkParseResults(/*includeNpmChecks*/false, dt, options, new UncachedNpmInfoClient());
+    try {
+        await checkParseResults(/*includeNpmChecks*/false, dt, options, new UncachedNpmInfoClient());
+    }
+    catch (e) {
+        if (!all) {
+            (await getAffectedPackagesFromDiff(dt, options.definitelyTypedPath, "affected")).dependentPackages.map(t => t.desc);
+        }
+
+        throw e;
+    }
     await runTests(dt, options.definitelyTypedPath, nProcesses, all ? "all" : "affected");
 }


### PR DESCRIPTION
For version errors, calculate and log dependent packages. Previously,
version errors were checked before the entirety of dependencies were
calculated. This gives  an iterative, annoying flavour to
fixing dependency errors:

1. Bump required version of express.
2. Get error on acl:
  Error: acl depends on express but has a lower required TypeScript version.
3. Bump required version of acl.
4. Get error on api-error-handler:
  Error: api-error-handler depends on express but has a lower required TypeScript version.
5. Bump required version of api-error-handler, etc etc.

Now an error thrown from check-require-version runs getAffectedPackages
and logs the dependents it finds. Then it re-throws the error. The above
process is now:

1. Bump required version of express.
2. Get error on acl, api-error-handler, etc etc.
3. Bump required version on all these packages.

The additional output looks like this:

Running: git rev-parse --verify master
06ddc1ccad76a7a5f766328a2fd0244bbfb06adf
Running: git diff master --name-status
M	types/express/index.d.ts
Testing 1 changed packages: express
Testing 234 dependent packages:acl,actions-on-google,api-error-handler,...