### PR TITLE
add vega-typings to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -137,6 +137,7 @@ ts-toolbelt
 tweetnacl
 typescript
 utility-types
+vega-typings
 vue
 vue-router
 vuex


### PR DESCRIPTION
[vega-typings](https://www.npmjs.com/package/vega-typings) is the typescript definitions for everything in the [vega project](https://github.com/vega/vega). I need this dependency to add definitions for [react-vega](https://www.npmjs.com/package/react-vega) ([link to PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37811)) and it could be useful for other projects ancillary to vega.