### PR TITLE
Add nock to whitelisted dependencies

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -94,6 +94,7 @@ meteor-typings
 moment
 monaco-editor
 mqtt
+nock
 normalize-url
 objection
 opentracing


### PR DESCRIPTION
This adds [`nock`](https://www.npmjs.com/package/nock) to the whitelisted dependencies to be able to merge https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38121.