### PR TITLE
Add final-form to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -62,6 +62,7 @@ expect
 express-graphql
 fast-glob
 fastify
+final-form
 flatpickr
 form-data
 google-auth-library


### PR DESCRIPTION
This is required for DefinitelyTyped/DefinitelyTyped#38200 to use the types bundled with final-form.