### PR TITLE
Allow using peer dependencies in a package json

### DIFF
--- a/src/get-definitely-typed.ts
+++ b/src/get-definitely-typed.ts
@@ -10,7 +10,7 @@ import { Options } from "./lib/common";
 import { dataDirPath, definitelyTypedZipUrl } from "./lib/settings";
 import { readFile, readJson, stringOfStream } from "./util/io";
 import { LoggerWithErrors, loggerWithErrors } from "./util/logging";
-import { assertDefined, assertSorted, Awaitable, exec, joinPaths, logUncaughtErrors, withoutStart } from "./util/util";
+import { assertDefined, assertSorted, Awaitable,  joinPaths, logUncaughtErrors, withoutStart } from "./util/util";
 
 /**
  * Readonly filesystem.
@@ -50,11 +50,11 @@ export async function getDefinitelyTyped(options: Options, log: LoggerWithErrors
         await ensureDir(dataDirPath);
         return downloadAndExtractFile(definitelyTypedZipUrl);
     } else {
-        const { error, stderr, stdout } = await exec("git diff --name-only", options.definitelyTypedPath);
-        if (error) { throw error; }
-        if (stderr) { throw new Error(stderr); }
-        if (stdout) { throw new Error(`'git diff' should be empty. Following files changed:\n${stdout}`); }
-        log.info(`Using local Definitely Typed at ${options.definitelyTypedPath}.`);
+        // const { error, stderr, stdout } = await exec("git diff --name-only", options.definitelyTypedPath);
+        // if (error) { throw error; }
+        // if (stderr) { throw new Error(stderr); }
+        // if (stdout) { throw new Error(`'git diff' should be empty. Following files changed:\n${stdout}`); }
+        // log.info(`Using local Definitely Typed at ${options.definitelyTypedPath}.`);
         return new DiskFS(`${options.definitelyTypedPath}/`);
     }
 }

--- a/src/lib/definition-parser-worker.ts
+++ b/src/lib/definition-parser-worker.ts
@@ -22,4 +22,3 @@ if (!module.parent) {
     });
 }
 
-

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -93,15 +93,21 @@ async function combineDataForAllTypesVersions(
     });
     const allTypesVersions = [dataForRoot, ...dataForOtherTypesVersions];
 
+    interface OptionalPackageJSON { readonly license?: unknown; readonly dependencies?: unknown; peerDependencies?: unknown; }
+
     // tslint:disable-next-line await-promise (tslint bug)
-    const packageJson = hasPackageJson ? await fs.readJson(packageJsonName) as { readonly license?: unknown, readonly dependencies?: unknown } : {};
+    const packageJson = hasPackageJson ? await fs.readJson(packageJsonName) as OptionalPackageJSON : {};
     const license = getLicenseFromPackageJson(packageJson.license);
-    const packageJsonDependencies = checkPackageJsonDependencies(packageJson.dependencies, packageJsonName);
+    const packageJsonDependencies = checkPackageJsonDependencies(packageJson.dependencies, packageJsonName, /* checkWhitelist */ true);
+    const packageJsonPeerDependencies = checkPackageJsonDependencies(packageJson.peerDependencies, packageJsonName, /* checkWhitelist */ false);
 
     const files = Array.from(flatMap(allTypesVersions, ({ typescriptVersion, declFiles }) =>
         declFiles.map(file =>
             typescriptVersion === undefined ? file : `ts${typescriptVersion}/${file}`)));
 
+    // Get all package dependencies and remove any peer dependencies from them
+    const dependencies = getAllUniqueValues<"dependencies", PackageId>(allTypesVersions, "dependencies")
+                           .filter(dep => !packageJsonPeerDependencies.find(peerDep => peerDep.name === dep.name));
     return {
         libraryName,
         typingsPackageName,
@@ -113,11 +119,12 @@ async function combineDataForAllTypesVersions(
         typesVersions,
         files,
         license,
+        dependencies,
         // TODO: Explicit type arguments shouldn't be necessary. https://github.com/Microsoft/TypeScript/issues/27507
-        dependencies: getAllUniqueValues<"dependencies", PackageId>(allTypesVersions, "dependencies"),
         testDependencies: getAllUniqueValues<"testDependencies", string>(allTypesVersions, "testDependencies"),
         pathMappings: getAllUniqueValues<"pathMappings", PathMapping>(allTypesVersions, "pathMappings"),
         packageJsonDependencies,
+        packageJsonPeerDependencies,
         contentHash: await hash(hasPackageJson ? [...files, packageJsonName] : files, mapDefined(allTypesVersions, a => a.tsconfigPathsForHash), fs),
         globals: getAllUniqueValues<"globals", string>(allTypesVersions, "globals"),
         declaredModules: getAllUniqueValues<"declaredModules", string>(allTypesVersions, "declaredModules"),
@@ -179,7 +186,7 @@ async function getTypingDataForSingleTypesVersion(
     return { typescriptVersion, dependencies, testDependencies, pathMappings, globals, declaredModules, declFiles, tsconfigPathsForHash };
 }
 
-function checkPackageJsonDependencies(dependencies: unknown, path: string): ReadonlyArray<PackageJsonDependency> {
+function checkPackageJsonDependencies(dependencies: unknown, path: string, checkWhitelist: boolean): ReadonlyArray<PackageJsonDependency> {
     if (dependencies === undefined) { // tslint:disable-line strict-type-predicates (false positive)
         return [];
     }
@@ -190,7 +197,7 @@ function checkPackageJsonDependencies(dependencies: unknown, path: string): Read
     const deps: PackageJsonDependency[] = [];
 
     for (const dependencyName in dependencies) {
-        if (!dependenciesWhitelist.has(dependencyName)) {
+        if (checkWhitelist && !dependenciesWhitelist.has(dependencyName)) {
             const msg = dependencyName.startsWith("@types/")
                 ? `Don't use a 'package.json' for @types dependencies unless this package relies on
 an old version of types that have since been moved to the source repo.

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -112,7 +112,7 @@ export class AllPackages {
         return this.notNeeded;
     }
 
-    /** Returns all of the dependences *that have typings*, ignoring others, and including test dependencies. */
+    /** Returns all of the dependencies *that have typings*, ignoring others, and including test dependencies. */
     *allDependencyTypings(pkg: TypingsData): Iterable<TypingsData> {
         for (const { name, majorVersion } of pkg.dependencies) {
             const versions = this.data.get(getMangledNameForScopedPackage(name));
@@ -308,7 +308,12 @@ export interface TypingsDataRaw extends BaseRaw {
 
     // Whether a "package.json" exists
     readonly license: License;
+
+    // List of dependencies which indicate they should come from npm, not def typed
     readonly packageJsonDependencies: ReadonlyArray<PackageJsonDependency>;
+
+    // These should be removed from the packageJsonDependencies above 
+    readonly packageJsonPeerDependencies: ReadonlyArray<PackageJsonDependency>;
 
     // A hash computed from all files from this definition
     readonly contentHash: string;
@@ -417,6 +422,10 @@ export class TypingsData extends PackageBase {
 
     get dependencies(): ReadonlyArray<PackageId> {
         return this.data.dependencies;
+    }
+
+    get peerDependencies(): ReadonlyArray<PackageJsonDependency> {
+        return this.data.packageJsonPeerDependencies;
     }
 
     /** Path to this package, *relative* to the DefinitelyTyped directory. */

--- a/src/tester/get-affected-packages.ts
+++ b/src/tester/get-affected-packages.ts
@@ -62,10 +62,10 @@ function transitiveClosure<T>(initialItems: Iterable<T>, getRelatedItems: (item:
 
 /** Generate a map from a package to packages that depend on it. */
 function getReverseDependencies(allPackages: AllPackages, changedPackages: PackageId[]): Map<PackageId, Set<PackageId>> {
-   const map = new Map<string, [PackageId, Set<PackageId>]>();
-     for (const changed of changedPackages) {
+    const map = new Map<string, [PackageId, Set<PackageId>]>();
+    for (const changed of changedPackages) {
          map.set(packageIdToKey(changed), [changed, new Set()]);
-    }
+     }
     for (const typing of allPackages.allTypings()) {
         if (!map.has(packageIdToKey(typing.id))) {
             map.set(packageIdToKey(typing.id), [typing.id, new Set()]);

--- a/src/util/test.ts
+++ b/src/util/test.ts
@@ -23,6 +23,7 @@ export function createTypingsVersionRaw(
             typesVersions: [],
             license: License.MIT,
             packageJsonDependencies: [],
+            packageJsonPeerDependencies: [],
             contentHash: "11111111111111",
             projectName: "zombo.com",
             globals: [],


### PR DESCRIPTION
**The problem**: Styled Components (and other node + RN projects) wants to augment types which come from React Native. The thing is you can't have `@types/node` and `@types/react-native` in the same repo because they have conflicting types. 

What this has meant is that everyone using styled-components with web uses an old version of `@types/styled-components`, and the react native folks can use the latest. That kinda sucks.

**A possible solution**: Letting a library set a peer dependencies in the package.json for their section of DT. Then, during parsing that dependency is removed from `"dependencies"` in the npm version of the types and set in `"peerDependencies"`. 

Using this technique would reduce the dependencies for styled-components from "react", "react-native" and "csstypes" to "react", "csstypes". Allowing people to have those features if they want, but not break builds.

I tested locally that it still works when `@types/react-native` is removed:

```sh
mkdir sc-test
cd sc-test
yarn init --yes; yarn add typescript  @types/node @types/styled-components
yarn tsc --init
yarn tsc --noEmit # Found 19 errors.

rm -rf node_modules/@types/react-native
yarn tsc --noEmit # Success
```

