### PR TITLE
Add @emotion/styled to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -6,6 +6,7 @@
 @babel/traverse
 @babel/types
 @electron/get
+@emotion/styled
 @jest/environment
 @jest/fake-timers
 @jest/transform


### PR DESCRIPTION
This is required by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38411 to use the StyledComponent definition from Emotion.