### PR TITLE
Allow suppressing messages back to github PRs via a commit message

### DIFF
--- a/src/publish-packages.ts
+++ b/src/publish-packages.ts
@@ -52,12 +52,15 @@ export default async function publishPackages(
             fetcher) as Array<{
             sha: string,
             commit: {
+                message: string,
                 author: {
                     date: string,
                 },
             },
         }>;
-        if (commits.length > 0) {
+
+        const firstCommit = commits[0];
+        if (firstCommit && !firstCommit.commit.message.includes("#no-publishing-comment")) {
             log("Found related commits; hash: " + commits[0].sha);
             const prs = await queryGithub(
                 `search/issues?q=is:pr%20is:merged%20${commits[0].sha}`,


### PR DESCRIPTION
Supports crafting a specially named commit which surpasses the GitHub message after publishing.