### PR TITLE
Add express-rate-limit for rate-limit-redis types

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -63,6 +63,7 @@ eventemitter2
 eventemitter3
 expect
 express-graphql
+express-rate-limit
 fast-glob
 fastify
 final-form


### PR DESCRIPTION
Added `express-rate-limit` to `dependenciesWhitelist.txt` for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39036