### PR TITLE
Update whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -94,6 +94,7 @@ log4js
 loglevel
 logrocket
 knex
+knockout
 magic-string
 mali
 meteor-typings


### PR DESCRIPTION
[knockout](https://github.com/knockout/knockout/blob/master/build/types/knockout.d.ts) has now it's own types

I'm working on https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37490