### PR TITLE
Add dotenv to whitelisted dependencies

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -56,6 +56,7 @@ decimal.js
 del
 dexie
 dnd-core
+dotenv
 egg
 electron
 electron-notarize


### PR DESCRIPTION
This adds [dotenv](http://npmjs.com/package/dotenv) to the whitelisted dependencies to be able to merge https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39170.