### PR TITLE
Proposal: Use full extension on types field to avoid FS lookups

### DIFF
--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -103,7 +103,7 @@ function createPackageJSON(typing: TypingsData, version: string, packages: AllPa
         license: typing.license,
         contributors: typing.contributors,
         main: "",
-        types: "index",
+        types: "index.d.ts",
         typesVersions:  makeTypesVersionsForPackageJson(typing.typesVersions),
         repository: {
             type: "git",


### PR DESCRIPTION
Before, `npx tsc --traceResolution -p . | grep @types/react/index`:

```
'package.json' has 'types' field 'index' that references '/Users/anbranc/Desktop/ts/node_modules/@types/react/index'.
File '/Users/anbranc/Desktop/ts/node_modules/@types/react/index' does not exist.
Loading module as file / folder, candidate module location '/Users/anbranc/Desktop/ts/node_modules/@types/react/index', target file type 'TypeScript'.
File '/Users/anbranc/Desktop/ts/node_modules/@types/react/index.ts' does not exist.
File '/Users/anbranc/Desktop/ts/node_modules/@types/react/index.tsx' does not exist.
File '/Users/anbranc/Desktop/ts/node_modules/@types/react/index.d.ts' exist - use it as a name resolution result.
Resolving real path for '/Users/anbranc/Desktop/ts/node_modules/@types/react/index.d.ts', result '/Users/anbranc/Desktop/ts/node_modules/@types/react/index.d.ts'.
======== Module name 'react' was successfully resolved to '/Users/anbranc/Desktop/ts/node_modules/@types/react/index.d.ts' with Package ID '@types/react/index.d.ts@16.9.9'. ========
```

After:

```
'package.json' has 'types' field 'index.d.ts' that references '/Users/anbranc/Desktop/ts/node_modules/@types/react/index.d.ts'.
File '/Users/anbranc/Desktop/ts/node_modules/@types/react/index.d.ts' exist - use it as a name resolution result.
Resolving real path for '/Users/anbranc/Desktop/ts/node_modules/@types/react/index.d.ts', result '/Users/anbranc/Desktop/ts/node_modules/@types/react/index.d.ts'.
======== Module name 'react' was successfully resolved to '/Users/anbranc/Desktop/ts/node_modules/@types/react/index.d.ts' with Package ID '@types/react/index.d.ts@16.9.9'. ========
```

Saves three file system lookups per package resolution!