### PR TITLE
Dual-publish Definitely Typed packages to github package registry

### DIFF
--- a/src/generate-packages.test.ts
+++ b/src/generate-packages.test.ts
@@ -1,6 +1,6 @@
 import { createPackageJSON, createReadme, getLicenseFileText } from "./generate-packages";
 import { Registry } from "./lib/common";
-import { TypingsData, TypingsDataRaw, License, AllPackages, readNotNeededPackages } from "./lib/packages";
+import { TypingsData, TypingsDataRaw, License, AllPackages, readNotNeededPackages, TypesDataFile } from "./lib/packages";
 import { testo } from "./util/test";
 import { createMockDT } from "./mocks"
 function createRawPackage(license: License): TypingsDataRaw {
@@ -22,6 +22,13 @@ function createRawPackage(license: License): TypingsDataRaw {
         projectName: "jquery.org",
         globals: [],
         declaredModules: ["juqery"],
+    }
+}
+function createTypesData(): TypesDataFile {
+    return {
+        "jquery": {
+            "1": createRawPackage(License.MIT)
+        },
     }
 }
 testo({
@@ -54,13 +61,7 @@ testo({
         expect(createReadme(typing, Registry.NPM)).toEqual(expect.stringContaining("Global values: none"));
     },
     async basicPackageJson() {
-        const rawDefinitions = {
-            "jquery": {
-                "1": createRawPackage(License.MIT)
-            },
-        };
-
-        const packages = AllPackages.from(rawDefinitions as any, await readNotNeededPackages(createMockDT()));
+        const packages = AllPackages.from(createTypesData(), await readNotNeededPackages(createMockDT()));
         const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
         expect(createPackageJSON(typing, "1.0", packages, Registry.NPM)).toEqual(`{
     "name": "@types/jquery",
@@ -88,25 +89,13 @@ testo({
 }`);
     },
     async githubPackageJsonName() {
-        const rawDefinitions = {
-            "jquery": {
-                "1": createRawPackage(License.MIT)
-            },
-        };
-
-        const packages = AllPackages.from(rawDefinitions as any, await readNotNeededPackages(createMockDT()));
+        const packages = AllPackages.from(createTypesData(), await readNotNeededPackages(createMockDT()));
         const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
         expect(createPackageJSON(typing, "1.0", packages, Registry.Github)).toEqual(
             expect.stringContaining('"name": "@testtypepublishing/jquery"'));
     },
     async githubPackageJsonRegistry() {
-        const rawDefinitions = {
-            "jquery": {
-                "1": createRawPackage(License.MIT)
-            },
-        };
-
-        const packages = AllPackages.from(rawDefinitions as any, await readNotNeededPackages(createMockDT()));
+        const packages = AllPackages.from(createTypesData(), await readNotNeededPackages(createMockDT()));
         const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
         const s = createPackageJSON(typing, "1.0", packages, Registry.Github);
         expect(s).toEqual(expect.stringContaining('publishConfig'));

--- a/src/generate-packages.test.ts
+++ b/src/generate-packages.test.ts
@@ -1,6 +1,6 @@
 import { createPackageJSON, createReadme, getLicenseFileText } from "./generate-packages";
 import { Registry } from "./lib/common";
-import { TypingsData, TypingsDataRaw, License, AllPackages } from "./lib/packages";
+import { TypingsData, TypingsDataRaw, License, AllPackages, readNotNeededPackages } from "./lib/packages";
 import { testo } from "./util/test";
 import { createMockDT } from "./mocks"
 function createRawPackage(license: License): TypingsDataRaw {
@@ -54,7 +54,13 @@ testo({
         expect(createReadme(typing, Registry.NPM)).toEqual(expect.stringContaining("Global values: none"));
     },
     async basicPackageJson() {
-        const packages = await AllPackages.read(createMockDT());
+        const rawDefinitions = {
+            "jquery": {
+                "1": createRawPackage(License.MIT)
+            },
+        };
+
+        const packages = AllPackages.from(rawDefinitions as any, await readNotNeededPackages(createMockDT()));
         const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
         expect(createPackageJSON(typing, "1.0", packages, Registry.NPM)).toEqual(`{
     "name": "@types/jquery",
@@ -82,13 +88,25 @@ testo({
 }`);
     },
     async githubPackageJsonName() {
-        const packages = await AllPackages.read(createMockDT());
+        const rawDefinitions = {
+            "jquery": {
+                "1": createRawPackage(License.MIT)
+            },
+        };
+
+        const packages = AllPackages.from(rawDefinitions as any, await readNotNeededPackages(createMockDT()));
         const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
         expect(createPackageJSON(typing, "1.0", packages, Registry.Github)).toEqual(
             expect.stringContaining('"name": "@testtypepublishing/jquery"'));
     },
     async githubPackageJsonRegistry() {
-        const packages = await AllPackages.read(createMockDT());
+        const rawDefinitions = {
+            "jquery": {
+                "1": createRawPackage(License.MIT)
+            },
+        };
+
+        const packages = AllPackages.from(rawDefinitions as any, await readNotNeededPackages(createMockDT()));
         const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
         const s = createPackageJSON(typing, "1.0", packages, Registry.Github);
         expect(s).toEqual(expect.stringContaining('publishConfig'));

--- a/src/generate-packages.test.ts
+++ b/src/generate-packages.test.ts
@@ -1,6 +1,6 @@
-import { createPackageJSON, createReadme, getLicenseFileText } from "./generate-packages";
+import { createNotNeededPackageJSON, createPackageJSON, createReadme, getLicenseFileText } from "./generate-packages";
 import { Registry } from "./lib/common";
-import { TypingsData, TypingsDataRaw, License, AllPackages, readNotNeededPackages, TypesDataFile } from "./lib/packages";
+import { TypingsData, TypingsDataRaw, License, AllPackages, readNotNeededPackages, TypesDataFile, NotNeededPackage } from "./lib/packages";
 import { testo } from "./util/test";
 import { createMockDT } from "./mocks"
 function createRawPackage(license: License): TypingsDataRaw {
@@ -30,6 +30,14 @@ function createTypesData(): TypesDataFile {
             "1": createRawPackage(License.MIT)
         },
     }
+}
+function createUnneededPackage() {
+    return new NotNeededPackage({
+        libraryName: "absalom",
+        typingsPackageName: "absalom",
+        asOfVersion: "1.1.1",
+        sourceRepoURL: "https://github.com/aardwulf/absalom",
+    })
 }
 testo({
     mitLicenseText() {
@@ -100,5 +108,27 @@ testo({
         const s = createPackageJSON(typing, "1.0", packages, Registry.Github);
         expect(s).toEqual(expect.stringContaining('publishConfig'));
         expect(s).toEqual(expect.stringContaining('"registry": "https://npm.pkg.github.com/"'));
+    },
+    async basicNotNeededPackageJson() {
+        const s = createNotNeededPackageJSON(createUnneededPackage(), Registry.NPM);
+        expect(s).toEqual(`{
+    "name": "@types/absalom",
+    "version": "1.1.1",
+    "typings": null,
+    "description": "Stub TypeScript definitions entry for absalom, which provides its own types definitions",
+    "main": "",
+    "scripts": {},
+    "author": "",
+    "repository": "https://github.com/aardwulf/absalom",
+    "license": "MIT",
+    "dependencies": {
+        "absalom": "*"
+    }
+}`);
+    },
+    async githubNotNeededPackageJson() {
+        const s = createNotNeededPackageJSON(createUnneededPackage(), Registry.Github);
+        expect(s).toEqual(expect.stringContaining('@testtypepublishing'));
+        expect(s).toEqual(expect.stringContaining('npm.pkg.github.com'));
     },
 });

--- a/src/generate-packages.test.ts
+++ b/src/generate-packages.test.ts
@@ -1,4 +1,5 @@
-import { createPackageJSON, createReadme, getLicenseFileText, Registry } from "./generate-packages";
+import { createPackageJSON, createReadme, getLicenseFileText } from "./generate-packages";
+import { Registry } from "./lib/common";
 import { TypingsData, TypingsDataRaw, License, AllPackages } from "./lib/packages";
 import { testo } from "./util/test";
 import { createMockDT } from "./mocks"
@@ -80,10 +81,17 @@ testo({
     "typeScriptVersion": "3.0"
 }`);
     },
-    async githubPackageJson() {
+    async githubPackageJsonName() {
         const packages = await AllPackages.read(createMockDT());
         const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
         expect(createPackageJSON(typing, "1.0", packages, Registry.Github)).toEqual(
             expect.stringContaining('"name": "@testtypepublishing/jquery"'));
+    },
+    async githubPackageJsonRegistry() {
+        const packages = await AllPackages.read(createMockDT());
+        const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
+        const s = createPackageJSON(typing, "1.0", packages, Registry.Github);
+        expect(s).toEqual(expect.stringContaining('publishConfig'));
+        expect(s).toEqual(expect.stringContaining('"registry": "https://npm.pkg.github.com/"'));
     },
 });

--- a/src/generate-packages.test.ts
+++ b/src/generate-packages.test.ts
@@ -1,0 +1,79 @@
+import { createPackageJSON, createReadme, getLicenseFileText } from "./generate-packages";
+import { TypingsData, TypingsDataRaw, License, AllPackages } from "./lib/packages";
+import { testo } from "./util/test";
+import { createMockDT } from "./mocks"
+function createRawPackage(license: License): TypingsDataRaw {
+    return {
+        libraryName: "jquery",
+        typingsPackageName: "jquery",
+        dependencies: [],
+        testDependencies: [],
+        pathMappings: [],
+        contributors: [{ name: "A", url: "b@c.d", githubUsername: "e" }],
+        libraryMajorVersion: 1,
+        libraryMinorVersion: 0,
+        minTsVersion: "3.0",
+        typesVersions: [],
+        files: ["index.d.ts", "jquery.test.ts"],
+        license,
+        packageJsonDependencies: [],
+        contentHash: "11",
+        projectName: "jquery.org",
+        globals: [],
+        declaredModules: ["juqery"],
+    }
+}
+testo({
+    mitLicenseText() {
+        const typings = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
+        expect(getLicenseFileText(typings)).toEqual(expect.stringContaining("MIT License"));
+    },
+    apacheLicenseText() {
+        const typings = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
+        expect(getLicenseFileText(typings)).toEqual(expect.stringContaining("Apache License, Version 2.0"));
+    },
+    basicReadme() {
+        const typings = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
+        expect(createReadme(typings)).toEqual(expect.stringContaining("This package contains type definitions for"));
+    },
+    readmeContainsProjectName() {
+        const typings = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
+        expect(createReadme(typings)).toEqual(expect.stringContaining("jquery.org"));
+    },
+    readmeNoDependencies() {
+        const typings = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
+        expect(createReadme(typings)).toEqual(expect.stringContaining("Dependencies: none"));
+    },
+    readmeNoGlobals() {
+        const typings = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
+        expect(createReadme(typings)).toEqual(expect.stringContaining("Global values: none"));
+    },
+    async basicPackageJson() {
+        const packages = await AllPackages.read(createMockDT());
+        const typings = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
+        expect(createPackageJSON(typings, "1.0", packages)).toEqual(`{
+    "name": "@types/jquery",
+    "version": "1.0",
+    "description": "TypeScript definitions for jquery",
+    "license": "MIT",
+    "contributors": [
+        {
+            "name": "A",
+            "url": "b@c.d",
+            "githubUsername": "e"
+        }
+    ],
+    "main": "",
+    "types": "index",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/jquery"
+    },
+    "scripts": {},
+    "dependencies": {},
+    "typesPublisherContentHash": "11",
+    "typeScriptVersion": "3.0"
+}`);
+    },
+});

--- a/src/generate-packages.test.ts
+++ b/src/generate-packages.test.ts
@@ -1,4 +1,4 @@
-import { createPackageJSON, createReadme, getLicenseFileText } from "./generate-packages";
+import { createPackageJSON, createReadme, getLicenseFileText, Registry } from "./generate-packages";
 import { TypingsData, TypingsDataRaw, License, AllPackages } from "./lib/packages";
 import { testo } from "./util/test";
 import { createMockDT } from "./mocks"
@@ -25,33 +25,33 @@ function createRawPackage(license: License): TypingsDataRaw {
 }
 testo({
     mitLicenseText() {
-        const typings = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
-        expect(getLicenseFileText(typings)).toEqual(expect.stringContaining("MIT License"));
+        const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
+        expect(getLicenseFileText(typing)).toEqual(expect.stringContaining("MIT License"));
     },
     apacheLicenseText() {
-        const typings = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(getLicenseFileText(typings)).toEqual(expect.stringContaining("Apache License, Version 2.0"));
+        const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
+        expect(getLicenseFileText(typing)).toEqual(expect.stringContaining("Apache License, Version 2.0"));
     },
     basicReadme() {
-        const typings = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(createReadme(typings)).toEqual(expect.stringContaining("This package contains type definitions for"));
+        const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
+        expect(createReadme(typing)).toEqual(expect.stringContaining("This package contains type definitions for"));
     },
     readmeContainsProjectName() {
-        const typings = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(createReadme(typings)).toEqual(expect.stringContaining("jquery.org"));
+        const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
+        expect(createReadme(typing)).toEqual(expect.stringContaining("jquery.org"));
     },
     readmeNoDependencies() {
-        const typings = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(createReadme(typings)).toEqual(expect.stringContaining("Dependencies: none"));
+        const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
+        expect(createReadme(typing)).toEqual(expect.stringContaining("Dependencies: none"));
     },
     readmeNoGlobals() {
-        const typings = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(createReadme(typings)).toEqual(expect.stringContaining("Global values: none"));
+        const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
+        expect(createReadme(typing)).toEqual(expect.stringContaining("Global values: none"));
     },
     async basicPackageJson() {
         const packages = await AllPackages.read(createMockDT());
-        const typings = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
-        expect(createPackageJSON(typings, "1.0", packages)).toEqual(`{
+        const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
+        expect(createPackageJSON(typing, "1.0", packages, Registry.NPM)).toEqual(`{
     "name": "@types/jquery",
     "version": "1.0",
     "description": "TypeScript definitions for jquery",
@@ -75,5 +75,11 @@ testo({
     "typesPublisherContentHash": "11",
     "typeScriptVersion": "3.0"
 }`);
+    },
+    async githubPackageJson() {
+        const packages = await AllPackages.read(createMockDT());
+        const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
+        expect(createPackageJSON(typing, "1.0", packages, Registry.Github)).toEqual(
+            expect.stringContaining('"name": "@testtypepublishing/jquery"'));
     },
 });

--- a/src/generate-packages.test.ts
+++ b/src/generate-packages.test.ts
@@ -34,19 +34,23 @@ testo({
     },
     basicReadme() {
         const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(createReadme(typing)).toEqual(expect.stringContaining("This package contains type definitions for"));
+        expect(createReadme(typing, Registry.NPM)).toEqual(expect.stringContaining("This package contains type definitions for"));
+    },
+    githubReadme() {
+        const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
+        expect(createReadme(typing, Registry.Github)).toEqual(expect.stringContaining("npm install --save @testtypepublishing/"));
     },
     readmeContainsProjectName() {
         const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(createReadme(typing)).toEqual(expect.stringContaining("jquery.org"));
+        expect(createReadme(typing, Registry.NPM)).toEqual(expect.stringContaining("jquery.org"));
     },
     readmeNoDependencies() {
         const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(createReadme(typing)).toEqual(expect.stringContaining("Dependencies: none"));
+        expect(createReadme(typing, Registry.NPM)).toEqual(expect.stringContaining("Dependencies: none"));
     },
     readmeNoGlobals() {
         const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(createReadme(typing)).toEqual(expect.stringContaining("Global values: none"));
+        expect(createReadme(typing, Registry.NPM)).toEqual(expect.stringContaining("Global values: none"));
     },
     async basicPackageJson() {
         const packages = await AllPackages.read(createMockDT());

--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -64,9 +64,9 @@ async function generateTypingPackage(typing: TypingsData, packages: AllPackages,
 }
 
 async function generateNotNeededPackage(pkg: NotNeededPackage, client: CachedNpmInfoClient, log: Logger): Promise<void> {
-    await writeCommonOutputs(pkg, createNotNeededPackageJSON(skipBadPublishes(pkg, client, log), Registry.NPM), pkg.readme(), Registry.NPM);
-    // TODO: Test this
-    await writeCommonOutputs(pkg, createNotNeededPackageJSON(skipBadPublishes(pkg, client, log), Registry.NPM), pkg.readme(), Registry.Github);
+    pkg = skipBadPublishes(pkg, client, log);
+    await writeCommonOutputs(pkg, createNotNeededPackageJSON(pkg, Registry.NPM), pkg.readme(), Registry.NPM);
+    await writeCommonOutputs(pkg, createNotNeededPackageJSON(pkg, Registry.Github), pkg.readme(), Registry.Github);
 }
 
 async function writeCommonOutputs(pkg: AnyPackage, packageJson: string, readme: string, registry: Registry): Promise<void> {

--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -19,6 +19,11 @@ import { withNpmCache, CachedNpmInfoClient, UncachedNpmInfoClient } from "./lib/
 
 const mitLicense = readFileSync(joinPaths(__dirname, "..", "LICENSE"), "utf-8");
 
+export enum Registry {
+    NPM,
+    Github,
+}
+
 if (!module.parent) {
     const tgz = !!yargs.argv.tgz;
     logUncaughtErrors(async () => {
@@ -91,10 +96,10 @@ async function outputFilePath(pkg: AnyPackage, filename: string): Promise<string
 
 interface Dependencies { [name: string]: string; }
 
-export function createPackageJSON(typing: TypingsData, version: string, packages: AllPackages): string {
+export function createPackageJSON(typing: TypingsData, version: string, packages: AllPackages, registry = Registry.NPM): string {
     // Use the ordering of fields from https://docs.npmjs.com/files/package.json
     const out: {} = {
-        name: typing.fullNpmName,
+        name: registry === Registry.NPM ? typing.fullNpmName : typing.fullGithubName,
         version,
         description: `TypeScript definitions for ${typing.libraryName}`,
         // keywords,

--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -91,7 +91,7 @@ async function outputFilePath(pkg: AnyPackage, filename: string): Promise<string
 
 interface Dependencies { [name: string]: string; }
 
-function createPackageJSON(typing: TypingsData, version: string, packages: AllPackages): string {
+export function createPackageJSON(typing: TypingsData, version: string, packages: AllPackages): string {
     // Use the ordering of fields from https://docs.npmjs.com/files/package.json
     const out: {} = {
         name: typing.fullNpmName,
@@ -163,7 +163,7 @@ function createNotNeededPackageJSON({ libraryName, license, name, fullNpmName, s
         4);
 }
 
-function createReadme(typing: TypingsData): string {
+export function createReadme(typing: TypingsData): string {
     const lines: string[] = [];
     lines.push("# Installation");
     lines.push(`> \`npm install --save ${typing.fullNpmName}\``);
@@ -196,7 +196,7 @@ function createReadme(typing: TypingsData): string {
     return lines.join("\r\n");
 }
 
-function getLicenseFileText(typing: AnyPackage): string {
+export function getLicenseFileText(typing: AnyPackage): string {
     switch (typing.license) {
         case License.MIT:
             return mitLicense;

--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -2,7 +2,7 @@ import { emptyDir } from "fs-extra";
 import * as yargs from "yargs";
 
 import { FS, getDefinitelyTyped } from "./get-definitely-typed";
-import { Options } from "./lib/common";
+import { Options, Registry } from "./lib/common";
 import {
     AllPackages, AnyPackage, DependencyVersion, getFullNpmName, License, NotNeededPackage, PackageJsonDependency, TypingsData,
 } from "./lib/packages";
@@ -18,11 +18,6 @@ import * as path from "path";
 import { withNpmCache, CachedNpmInfoClient, UncachedNpmInfoClient } from "./lib/npm-client";
 
 const mitLicense = readFileSync(joinPaths(__dirname, "..", "LICENSE"), "utf-8");
-
-export enum Registry {
-    NPM,
-    Github,
-}
 
 if (!module.parent) {
     const tgz = !!yargs.argv.tgz;
@@ -124,6 +119,9 @@ export function createPackageJSON(typing: TypingsData, version: string, packages
         typesPublisherContentHash: typing.contentHash,
         typeScriptVersion: typing.minTypeScriptVersion,
     };
+    if (registry === Registry.Github) {
+        (out as any).publishConfig = { registry: "https://npm.pkg.github.com/" };
+    }
 
     return JSON.stringify(out, undefined, 4);
 }

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -10,6 +10,12 @@ if (process.env.LONGJOHN) {
     longjohn.async_trace_limit = -1; // unlimited
 }
 
+/** Which registry to publish to */
+export enum Registry {
+    NPM,
+    Github,
+}
+
 /** Settings that may be determined dynamically. */
 export interface Options {
     /**

--- a/src/lib/npm-client.ts
+++ b/src/lib/npm-client.ts
@@ -1,4 +1,5 @@
 import assert = require("assert");
+import { Registry } from "./common";
 import { ensureFile, pathExists } from "fs-extra";
 import RegClient = require("npm-registry-client");
 import { resolve as resolveUrl } from "url";
@@ -137,8 +138,8 @@ function splitToFixedSizeGroups(names: ReadonlyArray<string>, chunkSize: number)
 }
 
 export class NpmPublishClient {
-    static async create(config?: RegClient.Config, registryName: "github" | "npm" = "npm"): Promise<NpmPublishClient> {
-        if (registryName === "github") {
+    static async create(config?: RegClient.Config, registry: Registry = Registry.NPM): Promise<NpmPublishClient> {
+        if (registry === Registry.Github) {
             return new this(new RegClient(config), { token: await getSecret(Secret.GITHUB_PUBLISH_ACCESS_TOKEN) }, githubRegistry);
         } else {
             return new this(new RegClient(config), { token: await getSecret(Secret.NPM_TOKEN) }, npmRegistry);

--- a/src/lib/package-publisher.ts
+++ b/src/lib/package-publisher.ts
@@ -1,8 +1,8 @@
 import assert = require("assert");
 import { TypeScriptVersion } from "definitelytyped-header-parser";
 
-import { readFileAndWarn } from "../lib/common";
-import { ChangedTyping } from "../lib/versions";
+import { readFileAndWarn } from "./common";
+import { ChangedTyping } from "./versions";
 import { Logger } from "../util/logging";
 import { joinPaths } from "../util/util";
 

--- a/src/lib/package-publisher.ts
+++ b/src/lib/package-publisher.ts
@@ -1,7 +1,7 @@
 import assert = require("assert");
 import { TypeScriptVersion } from "definitelytyped-header-parser";
 
-import { readFileAndWarn } from "./common";
+import { readFileAndWarn, Registry } from "./common";
 import { ChangedTyping } from "./versions";
 import { Logger } from "../util/logging";
 import { joinPaths } from "../util/util";
@@ -9,9 +9,9 @@ import { joinPaths } from "../util/util";
 import { NpmPublishClient } from "./npm-client";
 import { AnyPackage, NotNeededPackage } from "./packages";
 
-export async function publishTypingsPackage(client: NpmPublishClient, changedTyping: ChangedTyping, dry: boolean, log: Logger): Promise<void> {
+export async function publishTypingsPackage(client: NpmPublishClient, changedTyping: ChangedTyping, dry: boolean, log: Logger, registry: Registry): Promise<void> {
     const { pkg, version, latestVersion } = changedTyping;
-    await common(client, pkg, log, dry);
+    await common(client, pkg, log, dry, registry);
     if (pkg.isLatest) {
         await updateTypeScriptVersionTags(pkg, version, client, log, dry);
     }
@@ -24,16 +24,16 @@ export async function publishTypingsPackage(client: NpmPublishClient, changedTyp
     }
 }
 
-export async function publishNotNeededPackage(client: NpmPublishClient, pkg: NotNeededPackage, dry: boolean, log: Logger): Promise<void> {
+export async function publishNotNeededPackage(client: NpmPublishClient, pkg: NotNeededPackage, dry: boolean, log: Logger, registry: Registry): Promise<void> {
     log(`Deprecating ${pkg.name}`);
-    await common(client, pkg, log, dry);
+    await common(client, pkg, log, dry, registry);
     // Don't use a newline in the deprecation message because it will be displayed as "\n" and not as a newline.
     await deprecateNotNeededPackage(client, pkg, dry, log);
 }
 
-async function common(client: NpmPublishClient, pkg: AnyPackage, log: Logger, dry: boolean): Promise<void> {
+async function common(client: NpmPublishClient, pkg: AnyPackage, log: Logger, dry: boolean, registry: Registry): Promise<void> {
     const packageDir = pkg.outputDirectory;
-    const packageJson = await readFileAndWarn("generate", joinPaths(packageDir, "package.json"));
+    const packageJson = await readFileAndWarn("generate", joinPaths(packageDir + (registry === Registry.Github ? "-github" : ""), "package.json"));
     await client.publish(packageDir, packageJson, dry, log);
 }
 

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -207,7 +207,6 @@ export abstract class PackageBase {
     }
 
     /** '@definitelytyped%2ffoo' for a package 'foo'. */
-    // TODO: Test this one
     get fullEscapedGithubName(): string {
         return `@${orgName}%2f${this.name}`;
     }

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -5,7 +5,7 @@ import { FS } from "../get-definitely-typed";
 import { assertSorted, joinPaths, mapValues, unmangleScopedPackage } from "../util/util";
 
 import { readDataFile } from "./common";
-import { outputDirPath, scopeName } from "./settings";
+import { outputDirPath, orgName, scopeName } from "./settings";
 import { Semver } from "./versions";
 
 export class AllPackages {
@@ -196,9 +196,20 @@ export abstract class PackageBase {
         return getFullNpmName(this.name);
     }
 
+    /** '@definitelytyped/foo' for a package 'foo'. */
+    get fullGithubName(): string {
+        return getFullGithubName(this.name);
+    }
+
     /** '@types%2ffoo' for a package 'foo'. */
     get fullEscapedNpmName(): string {
         return `@${scopeName}%2f${this.name}`;
+    }
+
+    /** '@definitelytyped%2ffoo' for a package 'foo'. */
+    // TODO: Test this one
+    get fullEscapedGithubName(): string {
+        return `@${orgName}%2f${this.name}`;
     }
 
     abstract readonly major: number;
@@ -210,6 +221,10 @@ export abstract class PackageBase {
     get outputDirectory(): string {
         return joinPaths(outputDirPath, this.desc);
     }
+}
+
+export function getFullGithubName(packageName: string): string {
+    return `@${orgName}/${getMangledNameForScopedPackage(packageName)}`;
 }
 
 export function getFullNpmName(packageName: string): string {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -9,6 +9,8 @@ export const githubRegistry = `https://${githubRegistryHostName}/`;
 export const npmApi = "api.npmjs.org";
 /** Note: this is 'types' and not '@types' */
 export const scopeName = "types";
+/** TODO: Change this to definitelytyped when it's ready */
+export const orgName = "testtypepublishing";
 const root = joinPaths(__dirname, "..", "..");
 export const dataDirPath = joinPaths(root, "data");
 export const outputDirPath = joinPaths(root, "output");

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -1,0 +1,59 @@
+import { Dir, InMemoryDT } from "./get-definitely-typed";
+export function createMockDT() {
+    const root = new Dir(undefined);
+    root.set("notNeededPackages.json", `{
+    "packages": [{
+    "libraryName": "Angular 2",
+    "typingsPackageName": "angular",
+    "asOfVersion": "1.2.3",
+    "sourceRepoURL": "https://github.com/angular/angular2"
+  }]
+}`);
+    const types = root.subdir("types");
+    const jquery = types.subdir("jquery");
+    jquery.set("JQuery.d.ts", `
+declare var jQuery: 1;
+`);
+    jquery.set("index.d.ts", `// Type definitions for jquery 3.3
+// Project: https://jquery.com
+// Definitions by: Leonard Thieu <https://github.com/leonard-thieu>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference path="JQuery.d.ts" />
+
+export = jQuery;
+`);
+    jquery.set("jquery-tests.ts", `
+console.log(jQuery);
+`);
+    jquery.set("tsconfig.json", `{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "target": "es6",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jquery-tests.ts"
+    ]
+}
+
+`);
+
+    return new InMemoryDT(root, "DefinitelyTyped");
+}

--- a/src/parse-definitions.test.ts
+++ b/src/parse-definitions.test.ts
@@ -1,66 +1,8 @@
 import parseDefinitions from "./parse-definitions";
-import { Dir, InMemoryDT } from "./get-definitely-typed";
 import { loggerWithErrors } from "./util/logging";
 import { testo } from "./util/test";
+import { createMockDT } from "./mocks";
 
-function createMockDT() {
-    const root = new Dir(undefined);
-    root.set("notNeededPackages.json", `{
-    "packages": [{
-    "libraryName": "Angular 2",
-    "typingsPackageName": "angular",
-    "asOfVersion": "1.2.3",
-    "sourceRepoURL": "https://github.com/angular/angular2"
-  }]
-}`);
-    const types = root.subdir("types");
-    const jquery = types.subdir("jquery");
-    jquery.set("JQuery.d.ts", `
-declare var jQuery: 1;
-`);
-    jquery.set("index.d.ts", `// Type definitions for jquery 3.3
-// Project: https://jquery.com
-// Definitions by: Leonard Thieu <https://github.com/leonard-thieu>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
-
-/// <reference path="JQuery.d.ts" />
-
-export = jQuery;
-`);
-    jquery.set("jquery-tests.ts", `
-console.log(jQuery);
-`);
-    jquery.set("tsconfig.json", `{
-    "compilerOptions": {
-        "module": "commonjs",
-        "lib": [
-            "es6",
-            "dom"
-        ],
-        "target": "es6",
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
-        "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
-        "types": [],
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.d.ts",
-        "jquery-tests.ts"
-    ]
-}
-
-`);
-
-    return new InMemoryDT(root, "DefinitelyTyped");
-}
 testo({
     // async parseDefinitions() {
     //     const log = loggerWithErrors()[0]

--- a/src/publish-packages.ts
+++ b/src/publish-packages.ts
@@ -2,7 +2,7 @@ import * as yargs from "yargs";
 
 import appInsights = require("applicationinsights");
 import { getDefinitelyTyped } from "./get-definitely-typed";
-import { Options } from "./lib/common";
+import { Options, Registry } from "./lib/common";
 import { withNpmCache, NpmPublishClient, UncachedNpmInfoClient } from "./lib/npm-client";
 import { deprecateNotNeededPackage, publishNotNeededPackage, publishTypingsPackage } from "./lib/package-publisher";
 import { AllPackages } from "./lib/packages";
@@ -40,7 +40,7 @@ export default async function publishPackages(
         log("=== Publishing packages ===");
     }
 
-    const client = await NpmPublishClient.create();
+    const client = await NpmPublishClient.create(undefined, Registry.NPM);
 
     for (const cp of changedPackages.changedTypings) {
         log(`Publishing ${cp.pkg.desc}...`);

--- a/src/publish-packages.ts
+++ b/src/publish-packages.ts
@@ -127,13 +127,14 @@ export default async function publishPackages(
 
     withNpmCache(new UncachedNpmInfoClient(), async infoClient => {
         for (const n of changedPackages.changedNotNeededPackages) {
+            const target = skipBadPublishes(n, infoClient, log)
             try {
-                await publishNotNeededPackage(ghClient, skipBadPublishes(n, infoClient, log), dry, log, Registry.Github);
+                await publishNotNeededPackage(ghClient, target, dry, log, Registry.Github);
             } catch(e) {
                 // log and continue
                 log("publishing to github failed: " + e.toString());
             }
-            await publishNotNeededPackage(client, skipBadPublishes(n, infoClient, log), dry, log, Registry.NPM);
+            await publishNotNeededPackage(client, target, dry, log, Registry.NPM);
         }
     });
 


### PR DESCRIPTION
This PR is the next step in using the github package registry to support Automatic Type Acquisition. It generates two packages side-by-side on disk and calls `npm publish` on each. But the packages differ only in that the github package.json has a `publishConfig` entry that specifies the github package registry. This is the same strategy as the dual-publish of types-registry.

I plan to let this run for a few weeks until the package registry hits GA, then switch to publishing to the `@types` scope on the Types org.

Some notes:

1. I switched from "npm" | "github" to an enum, including in old code.
2. I still need to write tests of package removal and actual publishing. I'm not sure how annoying mocking the npm client will be, however. Since I'm on DT next week, watching closely all week after the merge will be worth more than unit tests. The unit tests are really for future changes when I've forgotten how all this works again.
3. The temporary target is `@testtypepublishing`, but the eventual target should be `@types` in order to provide a complete mirror of the `@types` scope on npm.