### PR TITLE
Add cosmiconfig to whitelisted dependencies

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -54,6 +54,7 @@ commander
 cordova-plugin-camera
 cordova-plugin-file
 cordova-plugin-file-transfer
+cosmiconfig
 cropperjs
 csstype
 cypress


### PR DESCRIPTION
This adds [cosmiconfig](https://npmjs.com/package/cosmiconfig) to the whitelisted dependencies to be able to merge https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40148.