### PR TITLE
feat: Make readme more readable

### DIFF
--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -178,18 +178,18 @@ function createReadme(typing: TypingsData): string {
     lines.push("");
 
     lines.push("# Details");
-    lines.push(`Files were exported from ${definitelyTypedURL}/tree/${sourceBranch}/types/${typing.subDirectoryPath}`);
+    lines.push(`Files were exported from ${definitelyTypedURL}/tree/${sourceBranch}/types/${typing.subDirectoryPath}.`);
 
     lines.push("");
-    lines.push("Additional Details");
+    lines.push("### Additional Details");
     lines.push(` * Last updated: ${(new Date()).toUTCString()}`);
     const dependencies = Array.from(typing.dependencies).map(d => getFullNpmName(d.name));
-    lines.push(` * Dependencies: ${dependencies.length ? dependencies.join(", ") : "none"}`);
-    lines.push(` * Global values: ${typing.globals.length ? typing.globals.join(", ") : "none"}`);
+    lines.push(` * Dependencies: ${dependencies.length ? dependencies.map(d => `[${d}](https://npmjs.com/package/${d})`).join(", ") : "none"}`);
+    lines.push(` * Global values: ${typing.globals.length ? typing.globals.map(g => `\`${g}\``).join(", ") : "none"}`);
     lines.push("");
 
     lines.push("# Credits");
-    const contributors = typing.contributors.map(({ name, url }) => `${name} <${url}>`).join(", ").replace(/, ([^,]+)$/, ", and $1");
+    const contributors = typing.contributors.map(({ name, url }) => `${name} (${url})`).join(", ").replace(/, ([^,]+)$/, ", and $1");
     lines.push(`These definitions were written by ${contributors}.`);
     lines.push("");
 


### PR DESCRIPTION
This PR changes the following to the published readme files:

- adds dots to the end of sentences
- sets "Additional details" as sub-header
- adds the appropriate npm link to every dependency
- adds a backtick to global values so they are displayed in `code style`
- sets the contributor's URL in brackets so they are visually separated from the contributor's name

<details>
<summary><b>Before</b></summary>

![image](https://user-images.githubusercontent.com/5497598/68340138-25825d00-00e6-11ea-9e9b-d9a630509ec9.png)
</details>

<details>
<summary><b>After</b></summary>

![image](https://user-images.githubusercontent.com/5497598/68340070-0aafe880-00e6-11ea-8da8-2c9cc6f06363.png)
</details>