### PR TITLE
Follow test references to calculate unused files

### DIFF
--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+       {
+            "type": "node",
+            "request": "attach",
+            "name": "9229",
+            "port": 9229,
+            "sourceMaps": true,
+            "stopOnEntry": false
+            
+        }
+    ]
+}

--- a/src/get-definitely-typed.ts
+++ b/src/get-definitely-typed.ts
@@ -250,9 +250,13 @@ class DiskFS implements FS {
 
 /** FS only handles simple paths like `foo/bar` or `../foo`. No `./foo` or `/foo`. */
 function validatePath(path: string): void {
-    if (path.startsWith(".") && path !== ".editorconfig" && !path.startsWith("../")
-        || path.startsWith("/")
-        || path.endsWith("/")) {
-        throw new Error(`Unexpected path ${path}`);
+    if (path.startsWith(".") && path !== ".editorconfig" && !path.startsWith("../")) {
+        throw new Error(`${path}: filesystem doesn't support paths of the form './x'.`);
+    }
+    else if (path.startsWith("/")) {
+        throw new Error(`${path}: filesystem doesn't support paths of the form '/xxx'.`);
+    }
+    else if (path.endsWith("/")) {
+        throw new Error(`${path}: filesystem doesn't support paths of the form 'xxx/'.`);
     }
 }

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -373,9 +373,7 @@ async function checkAllFilesUsed(ls: ReadonlyArray<string>, usedFiles: Set<strin
             throw new Error(`In ${packageName}: windows slash detected in ${fileName}`);
         }
     }
-    const otherFilesSet = new Set(otherFiles);
-    otherFilesSet.delete(unusedFilesName);
-    await checkAllUsedRecur(new Set(ls), usedFiles, otherFilesSet, fs);
+    await checkAllUsedRecur(new Set(ls), usedFiles,  new Set(otherFiles), fs);
 }
 
 async function checkAllUsedRecur(ls: Iterable<string>, usedFiles: Set<string>, unusedFiles: Set<string>, fs: FS): Promise<void> {
@@ -413,7 +411,7 @@ async function checkAllUsedRecur(ls: Iterable<string>, usedFiles: Set<string>, u
             }
             await checkAllUsedRecur(lssubdir, takeSubdirectoryOutOfSet(usedFiles), takeSubdirectoryOutOfSet(unusedFiles), subdir);
         } else {
-            if (lsEntry.toLowerCase() !== "readme.md" && lsEntry !== "NOTICE" && lsEntry !== ".editorconfig") {
+            if (lsEntry.toLowerCase() !== "readme.md" && lsEntry !== "NOTICE" && lsEntry !== ".editorconfig" && lsEntry !== unusedFilesName) {
                 throw new Error(`Unused file ${fs.debugPath()}/${lsEntry} (used files: ${JSON.stringify(Array.from(usedFiles))})`);
             }
         }

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -212,7 +212,6 @@ If this is an external library that provides typings,  please make a pull reques
     return deps;
 }
 
-// TODO: Test this somehow
 async function checkFilesFromTsConfig(packageName: string, tsconfig: TsConfig, directoryPath: string): Promise<void> {
     const tsconfigPath = `${directoryPath}/tsconfig.json`;
     if (tsconfig.include) {

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -6,7 +6,7 @@ import {
     computeHash, filter, flatMap, hasWindowsSlashes, join, mapAsyncOrdered, mapDefined, split, unique, unmangleScopedPackage, withoutStart,
 } from "../util/util";
 
-import getModuleInfo, { getTestDependencies } from "./module-info";
+import { allReferencedFiles, getModuleInfo } from "./module-info";
 import { getLicenseFromPackageJson, PackageId, PackageJsonDependency, PathMapping, TypingsDataRaw, TypingsVersionsRaw } from "./packages";
 import { dependenciesWhitelist } from "./settings";
 
@@ -154,6 +154,10 @@ async function getTypingDataForSingleTypesVersion(
     fs: FS,
     oldMajorVersion: number | undefined,
 ): Promise<TypingDataFromIndividualTypeScriptVersion> {
+    // 1. First calculate all references from types files (this should be unndeeded, except that some packages have no (0!) tests
+    // 2. calculate all referenced files from test files
+    // 3. combine those into one (minus test/non-d.ts files?), pass to getModuleInfo
+    // 4. pass all referenced test files into getTestDependencies, which is stripped down to just issue errors I think.
     const tsconfig = await fs.readJson("tsconfig.json") as TsConfig; // tslint:disable-line await-promise (tslint bug)
     const { typeFiles, testFiles } = await entryFilesFromTsConfig(packageName, tsconfig, fs.debugPath());
     const { dependencies: dependenciesWithDeclaredModules, globals, declaredModules, declFiles } =
@@ -162,10 +166,20 @@ async function getTypingDataForSingleTypesVersion(
     // Don't count an import of "x" as a dependency if we saw `declare module "x"` somewhere.
     const removeDeclaredModules = (modules: Iterable<string>): Iterable<string> => filter(modules, m => !declaredModulesSet.has(m));
     const dependenciesSet = new Set(removeDeclaredModules(dependenciesWithDeclaredModules));
-    const testDependencies = Array.from(removeDeclaredModules(await getTestDependencies(packageName, testFiles, dependenciesSet, fs)));
+    // TODO: Rework getTextDependencies to call allReferencedFiles and perform its checks
+    // const testDependencies = Array.from(removeDeclaredModules(await getTestDependencies(packageName, testFiles, dependenciesSet, fs)));
+    // ALSO: testDependencies now has a lot of external dependencies stuff in it that was previously found by scraping through tsconfig's actually-unused files
+    // example:
+
+    // test-a.ts -> a-global.d.ts -> react-fungi
+    // react-fungi needs to be in `dependencies`, not `testDependencies`, but doesn't matter for unusedFiles.
+    // SO: aim for producing dependencies/testDependencies
+    // this means transferring some files from testDep to dependencies, and figuring out what testDep is used for.
+    const testDependencies = Array.from(removeDeclaredModules(Object.keys(await allReferencedFiles(testFiles, fs, packageName, packageDirectory, "ts"))));;
+
     const { dependencies, pathMappings } = await calculateDependencies(packageName, tsconfig, dependenciesSet, oldMajorVersion);
 
-    const allUsedFiles = new Set(declFiles.concat(testFiles, ["tsconfig.json", "tslint.json"]));
+    const allUsedFiles = new Set([...declFiles, ...testFiles, ...testDependencies, "tsconfig.json", "tslint.json"]);
     await checkAllFilesUsed(ls, allUsedFiles, fs);
 
     // Double-check that no windows "\\" broke in.
@@ -421,7 +435,7 @@ async function checkAllUsedRecur(ls: Iterable<string>, usedFiles: Set<string>, u
             await checkAllUsedRecur(lssubdir, takeSubdirectoryOutOfSet(usedFiles), takeSubdirectoryOutOfSet(unusedFiles), subdir);
         } else {
             if (lsEntry.toLowerCase() !== "readme.md" && lsEntry !== "NOTICE" && lsEntry !== ".editorconfig") {
-                throw new Error(`Unused file ${fs.debugPath()}/${lsEntry}`);
+                throw new Error(`Unused file ${fs.debugPath()}/${lsEntry} (used files: ${JSON.stringify(Array.from(unusedFiles))})`);
             }
         }
     }

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -169,7 +169,7 @@ async function getTypingDataForSingleTypesVersion(
     const declaredModulesSet = new Set(declaredModules);
     // Don't count an import of "x" as a dependency if we saw `declare module "x"` somewhere.
     const dependenciesSet = new Set(filter(dependenciesWithDeclaredModules, m => !declaredModulesSet.has(m)));
-    const testDependencies = Array.from(filter(await getTestDependencies(packageName, tests.keys(), dependenciesSet, fs), m => !declaredModulesSet.has(m)));
+    const testDependencies = Array.from(filter(await getTestDependencies(packageName, types, tests.keys(), dependenciesSet, fs), m => !declaredModulesSet.has(m)));
 
     const { dependencies, pathMappings } = await calculateDependencies(packageName, tsconfig, dependenciesSet, oldMajorVersion);
     const tsconfigPathsForHash = JSON.stringify(tsconfig.compilerOptions.paths);

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -228,7 +228,7 @@ async function checkFilesFromTsConfig(packageName: string, tsconfig: TsConfig, d
             throw new Error(`In ${tsconfigPath}: Unnecessary "./" at the start of ${file}`);
         }
         if (file.endsWith(".d.ts") && file !== "index.d.ts") {
-            throw new Error(`Only index.d.ts may be listed explicitly in tsconfig's "files" entry.
+            throw new Error(`${packageName}: Only index.d.ts may be listed explicitly in tsconfig's "files" entry.
 Other d.ts files must either be referenced through index.d.ts, tests, or added to OTHER_FILES.txt.`)
         }
 

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -373,7 +373,9 @@ async function checkAllFilesUsed(ls: ReadonlyArray<string>, usedFiles: Set<strin
             throw new Error(`In ${packageName}: windows slash detected in ${fileName}`);
         }
     }
-    await checkAllUsedRecur(new Set(ls), usedFiles, new Set(otherFiles), fs);
+    const otherFilesSet = new Set(otherFiles);
+    otherFilesSet.delete(unusedFilesName);
+    await checkAllUsedRecur(new Set(ls), usedFiles, otherFilesSet, fs);
 }
 
 async function checkAllUsedRecur(ls: Iterable<string>, usedFiles: Set<string>, unusedFiles: Set<string>, fs: FS): Promise<void> {

--- a/src/lib/module-info.test.ts
+++ b/src/lib/module-info.test.ts
@@ -3,6 +3,10 @@ import { testo } from "../util/test";
 import { createMockDT } from "../mocks"
 const fs = createMockDT();
 testo({
+    async allReferencedFilesFromTsconfigFiles() {
+        const m = await allReferencedFiles(["index.d.ts", "boring-tests.ts"], fs.subDir("types").subDir("boring"), "boring", "types/boring", "ts")
+        expect(Array.from(m.keys())).toEqual(["index.d.ts", "boring-tests.ts", "secondary.d.ts", "commonjs.d.ts", "tertiary.d.ts"])
+    },
     async allReferencedFilesFromTestIncludesSecondaryInternalFiles() {
         const m = await allReferencedFiles(["boring-tests.ts"], fs.subDir("types").subDir("boring"), "boring", "types/boring", "ts")
         expect(Array.from(m.keys())).toEqual(["boring-tests.ts", "secondary.d.ts", "commonjs.d.ts", "tertiary.d.ts"])

--- a/src/lib/module-info.test.ts
+++ b/src/lib/module-info.test.ts
@@ -53,7 +53,7 @@ testo({
 `);
         const { types } = await allReferencedFiles(["index.d.ts"], fs, "typeref-fails", "types/typeref-fails")
         expect(Array.from(types.keys())).toEqual(["index.d.ts"])
-        await expect(getModuleInfo("typeref-fails", types)).rejects.toThrow();
+        await expect(getModuleInfo("typeref-fails", types)).rejects.toThrow("do not directly import specific versions of another types package");
     },
     async getTestDependenciesWorks() {
         const { types, tests } = await getBoringReferences();

--- a/src/lib/module-info.test.ts
+++ b/src/lib/module-info.test.ts
@@ -8,33 +8,33 @@ async function getBoringReferences() {
 }
 testo({
     async allReferencedFilesFromTsconfigFiles() {
-        const [types, tests] = await getBoringReferences();
+        const { types, tests } = await getBoringReferences();
         expect(Array.from(types.keys())).toEqual(["index.d.ts", "secondary.d.ts", "commonjs.d.ts", "quaternary.d.ts", "tertiary.d.ts"])
         expect(Array.from(tests.keys())).toEqual(["boring-tests.ts"])
     },
     async allReferencedFilesFromTestIncludesSecondaryInternalFiles() {
-        const [types, tests] = await allReferencedFiles(["boring-tests.ts"], fs.subDir("types").subDir("boring"), "boring", "types/boring")
+        const { types, tests } = await allReferencedFiles(["boring-tests.ts"], fs.subDir("types").subDir("boring"), "boring", "types/boring")
         expect(Array.from(types.keys())).toEqual(["secondary.d.ts", "commonjs.d.ts", "quaternary.d.ts", "tertiary.d.ts"])
         expect(Array.from(tests.keys())).toEqual(["boring-tests.ts"])
     },
     async allReferencedFilesFromTsconfigGlobal() {
-        const [types, tests] = await allReferencedFiles(["jquery-tests.ts", "index.d.ts"], fs.subDir("types").subDir("jquery"), "jquery", "types/jquery")
+        const { types, tests } = await allReferencedFiles(["jquery-tests.ts", "index.d.ts"], fs.subDir("types").subDir("jquery"), "jquery", "types/jquery")
         expect(Array.from(types.keys())).toEqual(["index.d.ts", "JQuery.d.ts"])
         expect(Array.from(tests.keys())).toEqual(["jquery-tests.ts"])
     },
     async allReferencedFilesFromTestIncludesSecondaryTripleSlashTypes() {
-        const [types,tests] = await allReferencedFiles(["globby-tests.ts", "test/other-tests.ts"], fs.subDir("types").subDir("globby"), "globby", "types/globby")
+        const { types, tests } = await allReferencedFiles(["globby-tests.ts", "test/other-tests.ts"], fs.subDir("types").subDir("globby"), "globby", "types/globby")
         expect(Array.from(types.keys())).toEqual(["merges.d.ts"])
         expect(Array.from(tests.keys())).toEqual(["globby-tests.ts", "test/other-tests.ts"])
     },
     async getModuleInfoWorksWithOtherFiles() {
-        const [types] = await getBoringReferences();
+        const { types } = await getBoringReferences();
         types.set("untested.d.ts", ts.createSourceFile("untested.d.ts", await fs.subDir("types").subDir("boring").readFile("untested.d.ts"), ts.ScriptTarget.Latest, false));
         const i = await getModuleInfo("boring", types);
         expect(i.dependencies).toEqual(new Set(['manual', 'react', 'react-default', 'things', 'vorticon']));
     },
     async getTestDependenciesWorks() {
-        const [types, tests] = await getBoringReferences();
+        const { types, tests } = await getBoringReferences();
         const i = await getModuleInfo("boring", types);
         const d = await getTestDependencies("boring", tests.keys(), i.dependencies, fs.subDir("types").subDir("boring"));
         expect(d).toEqual(new Set(["super-big-fun-hus"]));

--- a/src/lib/module-info.test.ts
+++ b/src/lib/module-info.test.ts
@@ -1,6 +1,7 @@
 import { allReferencedFiles, getModuleInfo, getTestDependencies } from "./module-info";
 import { testo } from "../util/test";
 import { createMockDT } from "../mocks"
+import * as ts from 'typescript'
 const fs = createMockDT();
 async function getBoringReferences() {
     return allReferencedFiles(["index.d.ts", "boring-tests.ts"], fs.subDir("types").subDir("boring"), "boring", "types/boring")
@@ -26,10 +27,11 @@ testo({
         expect(Array.from(types.keys())).toEqual(["merges.d.ts"])
         expect(Array.from(tests.keys())).toEqual(["globby-tests.ts", "test/other-tests.ts"])
     },
-    async getModuleInfoWorks() {
+    async getModuleInfoWorksWithOtherFiles() {
         const [types] = await getBoringReferences();
+        types.set("untested.d.ts", ts.createSourceFile("untested.d.ts", await fs.subDir("types").subDir("boring").readFile("untested.d.ts"), ts.ScriptTarget.Latest, false));
         const i = await getModuleInfo("boring", types);
-        expect(i.dependencies).toEqual(new Set(['react', 'react-default', 'things', 'vorticon']));
+        expect(i.dependencies).toEqual(new Set(['manual', 'react', 'react-default', 'things', 'vorticon']));
     },
     async getTestDependenciesWorks() {
         const [types, tests] = await getBoringReferences();

--- a/src/lib/module-info.test.ts
+++ b/src/lib/module-info.test.ts
@@ -1,0 +1,34 @@
+import { allReferencedFiles, getModuleInfo } from "./module-info";
+import { testo } from "../util/test";
+import { createMockDT } from "../mocks"
+const fs = createMockDT();
+testo({
+    async allReferencedFilesFromTestIncludesSecondaryInternalFiles() {
+        const m = await allReferencedFiles(["boring-tests.ts"], fs.subDir("types").subDir("boring"), "boring", "types/boring", "ts")
+        expect(Array.from(m.keys())).toEqual(["boring-tests.ts", "secondary.d.ts", "commonjs.d.ts", "tertiary.d.ts"])
+    },
+    async allReferencedFilesFromTestIncludesTripleSlashTypes() {
+        const m = await allReferencedFiles(["jquery-tests.ts"], fs.subDir("types").subDir("jquery"), "jquery", "types/jquery", "ts")
+        expect(Array.from(m.keys())).toEqual(["jquery-tests.ts", "index.d.ts", "JQuery.d.ts"])
+    },
+    async allReferencedFilesFromTestIncludesSecondaryTripleSlashTypes() {
+        const m = await allReferencedFiles(["globby-tests.ts", "other-tests.ts"], fs.subDir("types").subDir("globby"), "globby", "types/globby", "ts")
+        expect(Array.from(m.keys())).toEqual(["globby-tests.ts", "other-tests.ts", "index.d.ts", "merges.d.ts", "sneaky.d.ts"])
+    },
+    async getModuleInfoWorks() {
+        const m = await getModuleInfo("boring", "types/boring", ["index.d.ts", "secondary.d.ts", "tertiary.d.ts", "commonjs.d.ts"], fs.subDir("types").subDir("boring"));
+        expect(m.dependencies).toEqual(new Set(['react', 'react-default', 'things', 'vorticon']));
+    },
+    // TODO: For boring,gettypedataForSingleTypesVersion should start with tsconfig="index.d.ts", "boring-tests.ts" and
+    // find all the used types files: "index.d.ts", "secondary", "tertiary", "commonjs"
+    // TODO: GetTestDependencies should be checkTestDep and needs to be refactored similar to getModuleInfo to take a list of used files
+
+    // allReferencedFiles -> { usedTypeFiles, usedTestFiles }
+    // getModuleInfo :: usedTypeFiles -> { declFiles: usedTypeFiles, dependencies, declaredModules, globals } (the last two don't change)
+    // getTestDep :: usedTestFiles -> testDependencies I guess?
+
+    // entryFilesFromTsConfig is not needed anymore (maybe)
+
+
+    // NOTE: getTypingInfo is the actual entry point, not getTypeDataForSingleTypesVersion x_x
+})

--- a/src/lib/module-info.test.ts
+++ b/src/lib/module-info.test.ts
@@ -10,12 +10,12 @@ async function getBoringReferences() {
 testo({
     async allReferencedFilesFromTsconfigFiles() {
         const { types, tests } = await getBoringReferences();
-        expect(Array.from(types.keys())).toEqual(["index.d.ts", "secondary.d.ts", "commonjs.d.ts", "quaternary.d.ts", "tertiary.d.ts"])
+        expect(Array.from(types.keys())).toEqual(["index.d.ts", "secondary.d.ts", "commonjs.d.ts", "v1.d.ts", "quaternary.d.ts", "tertiary.d.ts"])
         expect(Array.from(tests.keys())).toEqual(["boring-tests.ts"])
     },
     async allReferencedFilesFromTestIncludesSecondaryInternalFiles() {
         const { types, tests } = await allReferencedFiles(["boring-tests.ts"], fs.subDir("types").subDir("boring"), "boring", "types/boring")
-        expect(Array.from(types.keys())).toEqual(["secondary.d.ts", "commonjs.d.ts", "quaternary.d.ts", "tertiary.d.ts"])
+        expect(Array.from(types.keys())).toEqual(["secondary.d.ts", "commonjs.d.ts", "v1.d.ts", "quaternary.d.ts", "tertiary.d.ts"])
         expect(Array.from(tests.keys())).toEqual(["boring-tests.ts"])
     },
     async allReferencedFilesFromTsconfigGlobal() {
@@ -58,7 +58,7 @@ testo({
     async getTestDependenciesWorks() {
         const { types, tests } = await getBoringReferences();
         const i = await getModuleInfo("boring", types);
-        const d = await getTestDependencies("boring", tests.keys(), i.dependencies, fs.subDir("types").subDir("boring"));
+        const d = await getTestDependencies("boring", types, tests.keys(), i.dependencies, fs.subDir("types").subDir("boring"));
         expect(d).toEqual(new Set(["super-big-fun-hus"]));
     },
 })

--- a/src/lib/module-info.test.ts
+++ b/src/lib/module-info.test.ts
@@ -39,17 +39,4 @@ testo({
         const d = await getTestDependencies("boring", tests.keys(), i.dependencies, fs.subDir("types").subDir("boring"));
         expect(d).toEqual(new Set(["super-big-fun-hus"]));
     }
-    // TODO: After all tests pass, I need to dump the current dep/testdep/[unused files?] from a current DT and then compare.
-    // TODO: For boring,gettypedataForSingleTypesVersion should start with tsconfig="index.d.ts", "boring-tests.ts" and
-    // find all the used types files: "index.d.ts", "secondary", "tertiary", "commonjs"
-    // TODO: GetTestDependencies should be checkTestDep and needs to be refactored similar to getModuleInfo to take a list of used files
-
-    // allReferencedFiles -> { usedTypeFiles, usedTestFiles }
-    // getModuleInfo :: usedTypeFiles -> { declFiles: usedTypeFiles, dependencies, declaredModules, globals } (the last two don't change)
-    // getTestDep :: usedTestFiles -> testDependencies I guess?
-
-    // entryFilesFromTsConfig is not needed anymore (maybe)
-
-
-    // NOTE: getTypingInfo is the actual entry point, not getTypeDataForSingleTypesVersion x_x
 })

--- a/src/lib/module-info.ts
+++ b/src/lib/module-info.ts
@@ -237,6 +237,7 @@ function findReferencedFiles(src: ts.SourceFile, packageName: string, subDirecto
         refs.push(ref);
     }
 
+    /** boring/foo -> ./foo when subDirectory === '.'; ../foo when it's === 'x'; ../../foo when it's 'x/y' */
     function convertToRelativeReference(name: string) {
         const relative = "." + "/..".repeat(subDirectory === "." ? 0 : subDirectory.split("/").length);
         return relative + name.slice(packageName.length);

--- a/src/lib/module-info.ts
+++ b/src/lib/module-info.ts
@@ -127,7 +127,7 @@ function rootName(importText: string): string {
         // Use second "/"
         slash = importText.indexOf("/", slash + 1);
     }
-    if (slash > -1 && importText.slice(slash + 1).match(/v\d+/)) {
+    if (slash > -1 && importText.slice(slash + 1).match(/\/v\d+$/)) {
         const name = importText.slice(0, slash);
         const version = importText.slice(slash + 2);
         throw new Error(`${importText}: do not directly import specific versions of another types package.

--- a/src/lib/module-info.ts
+++ b/src/lib/module-info.ts
@@ -127,7 +127,7 @@ function rootName(importText: string): string {
         // Use second "/"
         slash = importText.indexOf("/", slash + 1);
     }
-    if (slash > -1 && importText.slice(slash + 1).match(/\/v\d+$/)) {
+    if (slash > -1 && importText.slice(slash).match(/\/v\d+$/)) {
         const name = importText.slice(0, slash);
         const version = importText.slice(slash + 2);
         throw new Error(`${importText}: do not directly import specific versions of another types package.

--- a/src/lib/module-info.ts
+++ b/src/lib/module-info.ts
@@ -78,7 +78,7 @@ export async function getModuleInfo(packageName: string, all: Map<string, ts.Sou
         }
     }
 
-    return { declFiles: sort(all.keys()), dependencies, declaredModules, globals: sort(globals) };
+    return { dependencies, declaredModules, globals: sort(globals) };
 }
 
 /**
@@ -100,8 +100,6 @@ function sourceFileExportsSomething({ statements }: ts.SourceFile): boolean {
 }
 
 interface ModuleInfo {
-    // Every declaration file used (starting from the entry point)
-    declFiles: string[];
     dependencies: Set<string>;
     // Anything from a `declare module "foo"`
     declaredModules: string[];

--- a/src/lib/module-info.ts
+++ b/src/lib/module-info.ts
@@ -357,6 +357,6 @@ export async function getTestDependencies(
     return testDependencies;
 }
 
-function createSourceFile(filename: string, content: string): ts.SourceFile {
+export function createSourceFile(filename: string, content: string): ts.SourceFile {
     return ts.createSourceFile(filename, content, ts.ScriptTarget.Latest, /*setParentNodes*/false);
 }

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -57,7 +57,7 @@ console.log(jQuery);
 `);
 
     const boring = types.subdir("boring");
-    boring.set("index.d.ts", `
+    boring.set("index.d.ts", `// Type definitions for boring 1.0
 // Project: https://boring.com
 // Definitions by: Some Guy From Space <https://github.com/goodspaceguy420>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -114,7 +114,7 @@ import australia = require('boring/commonjs');
 }`);
 
     const globby = types.subdir("globby");
-    globby.set("index.d.ts", `
+    globby.set("index.d.ts", `// Type definitions for globby 0.1
 // Project: https://globby-gloopy.com
 // Definitions by: The Dragon Quest Slime <https://github.com/gloopyslime>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -10,52 +10,6 @@ export function createMockDT() {
   }]
 }`);
     const types = root.subdir("types");
-    const jquery = types.subdir("jquery");
-    jquery.set("JQuery.d.ts", `
-declare var jQuery: 1;
-`);
-    jquery.set("index.d.ts", `// Type definitions for jquery 3.3
-// Project: https://jquery.com
-// Definitions by: Leonard Thieu <https://github.com/leonard-thieu>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
-
-/// <reference path="JQuery.d.ts" />
-
-export = jQuery;
-`);
-    jquery.set("jquery-tests.ts", `
-/// <reference types="jquery" />
-console.log(jQuery);
-`);
-    jquery.set("tsconfig.json", `{
-    "compilerOptions": {
-        "module": "commonjs",
-        "lib": [
-            "es6",
-            "dom"
-        ],
-        "target": "es6",
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
-        "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
-        "types": [],
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.d.ts",
-        "jquery-tests.ts"
-    ]
-}
-
-`);
-
     const boring = types.subdir("boring");
     boring.set("index.d.ts", `// Type definitions for boring 1.0
 // Project: https://boring.com
@@ -67,14 +21,21 @@ export const drills: number;
 `);
     boring.set("secondary.d.ts", `
 import deffo from 'react-default';
+import { mammoths } from 'boring/quaternary';
 export const hovercars: unknown;
 declare module "boring/fake" {
     import { stock } from 'boring/tertiary';
+}
+declare module "other" {
+    export const augmented: true;
 }
 `);
     boring.set("tertiary.d.ts", `
 import { stuff } from 'things';
 export var stock: number;
+`);
+    boring.set("quaternary.d.ts", `
+export const mammoths: object;
 `);
     boring.set("commonjs.d.ts", `
 import vortex = require('vorticon');
@@ -129,10 +90,10 @@ declare var y: number
 declare var ka: number
 `);
     globby.set("globby-tests.ts", `
-/// <reference types="globby" />
 var z = x;
 `);
-    globby.set("other-tests.ts", `
+    const tests = globby.subdir("test");
+    tests.set("other-tests.ts", `
 /// <reference types="globby/merges" />
 var z = y;
 `);
@@ -159,8 +120,53 @@ var z = y;
     "files": [
         "index.d.ts",
         "globby-tests.ts",
-        "other-tests.ts"
+        "test/other-tests.ts"
     ]
 }`);
+    const jquery = types.subdir("jquery");
+    jquery.set("JQuery.d.ts", `
+declare var jQuery: 1;
+`);
+    jquery.set("index.d.ts", `// Type definitions for jquery 3.3
+// Project: https://jquery.com
+// Definitions by: Leonard Thieu <https://github.com/leonard-thieu>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference path="JQuery.d.ts" />
+
+export = jQuery;
+`);
+    jquery.set("jquery-tests.ts", `
+console.log(jQuery);
+`);
+    jquery.set("tsconfig.json", `{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "target": "es6",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jquery-tests.ts"
+    ]
+}
+
+`);
+
     return new InMemoryDT(root, "DefinitelyTyped");
 }

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -42,6 +42,9 @@ import vortex = require('vorticon');
 declare const australia: {};
 export = australia;
 `);
+    boring.set("v1.d.ts", `
+export const inane: true | false;
+`);
     boring.set("untested.d.ts", `
 import { help } from 'manual';
 export const fungible: false;
@@ -51,6 +54,7 @@ import { superstor } from "super-big-fun-hus";
 import { drills } from "boring";
 import { hovercars } from "boring/secondary";
 import australia = require('boring/commonjs');
+import { inane } from "boring/v1";
 `);
     boring.set("OTHER_FILES.txt", `
 untested.d.ts

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -25,6 +25,7 @@ declare var jQuery: 1;
 export = jQuery;
 `);
     jquery.set("jquery-tests.ts", `
+/// <reference types="jquery" />
 console.log(jQuery);
 `);
     jquery.set("tsconfig.json", `{
@@ -55,5 +56,111 @@ console.log(jQuery);
 
 `);
 
+    const boring = types.subdir("boring");
+    boring.set("index.d.ts", `
+// Project: https://boring.com
+// Definitions by: Some Guy From Space <https://github.com/goodspaceguy420>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'react';
+export const drills: number;
+`);
+    boring.set("secondary.d.ts", `
+import deffo from 'react-default';
+export const hovercars: unknown;
+declare module "boring/fake" {
+    import { stock } from 'boring/tertiary';
+}
+`);
+    boring.set("tertiary.d.ts", `
+import { stuff } from 'things';
+export var stock: number;
+`);
+    boring.set("commonjs.d.ts", `
+import vortex = require('vorticon');
+declare const australia: {};
+export = australia;
+`);
+    boring.set("boring-tests.ts", `
+import { superstor } from "super-big-fun-hus";
+import { drills } from "boring";
+import { hovercars } from "boring/secondary";
+import australia = require('boring/commonjs');
+`);
+    boring.set("tsconfig.json", `{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "target": "es6",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "boring-tests.ts"
+    ]
+}`);
+
+    const globby = types.subdir("globby");
+    globby.set("index.d.ts", `
+// Project: https://globby-gloopy.com
+// Definitions by: The Dragon Quest Slime <https://github.com/gloopyslime>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="./sneaky.d.ts" />
+declare var x: number
+`);
+    globby.set("merges.d.ts", `
+declare var y: number
+`);
+    globby.set("sneaky.d.ts", `
+declare var ka: number
+`);
+    globby.set("globby-tests.ts", `
+/// <reference types="globby" />
+var z = x;
+`);
+    globby.set("other-tests.ts", `
+/// <reference types="globby/merges" />
+var z = y;
+`);
+    globby.set("tsconfig.json", `{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "target": "es6",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "globby-tests.ts",
+        "other-tests.ts"
+    ]
+}`);
     return new InMemoryDT(root, "DefinitelyTyped");
 }

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -88,6 +88,7 @@ untested.d.ts
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="./sneaky.d.ts" />
+/// <reference types="andere/snee" />
 declare var x: number
 `);
     globby.set("merges.d.ts", `

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -42,11 +42,18 @@ import vortex = require('vorticon');
 declare const australia: {};
 export = australia;
 `);
+    boring.set("untested.d.ts", `
+import { help } from 'manual';
+export const fungible: false;
+`);
     boring.set("boring-tests.ts", `
 import { superstor } from "super-big-fun-hus";
 import { drills } from "boring";
 import { hovercars } from "boring/secondary";
 import australia = require('boring/commonjs');
+`);
+    boring.set("OTHER_FILES.txt", `
+untested.d.ts
 `);
     boring.set("tsconfig.json", `{
     "compilerOptions": {

--- a/src/parse-definitions.test.ts
+++ b/src/parse-definitions.test.ts
@@ -20,7 +20,7 @@ testo({
         const log = loggerWithErrors()[0];
         const defs = await parseDefinitions(createMockDT(), undefined, log);
         expect(defs.allNotNeeded().length).toBe(1)
-        expect(defs.allTypings().length).toBe(1)
+        expect(defs.allTypings().length).toBe(3)
         const j = defs.tryGetLatestVersion("jquery")
         expect(j).toBeDefined()
         expect(j!.fullNpmName).toContain("types")

--- a/src/parse-definitions.ts
+++ b/src/parse-definitions.ts
@@ -37,6 +37,7 @@ export default async function parseDefinitions(dt: FS, parallel: ParallelOptions
 
     const typings: { [name: string]: TypingsVersionsRaw } = {};
 
+    const start = Date.now();
     if (parallel) {
         log.info("Parsing in parallel...");
         await runWithChildProcesses({
@@ -54,6 +55,7 @@ export default async function parseDefinitions(dt: FS, parallel: ParallelOptions
             typings[packageName] = await getTypingInfo(packageName, typesFS.subDir(packageName));
         }
     }
+    log.info("Parsing took " + ((Date.now() - start) / 1000) + " s");
     await writeDataFile(typesDataFilename, sorted(typings));
     return AllPackages.from(typings, await readNotNeededPackages(dt));
 }


### PR DESCRIPTION
To make sure that I didn't break anything, I dumped the list of dependencies generated during parsing. In `getTypingInfo`, I added the following code:

```ts
    console.log(`"${packageName}": {`)
    let first = true
    for (const k in res) {
        if (first)
            first = false
        else
            console.log(",")
        console.log(`  "${k}": ${JSON.stringify(res[k].dependencies.map(d => d.name))}`)
    }
    console.log("},")
```

I put the same code in the production version of types-publisher. This produced (1) almost-legal JSON (2) a diffable file for both. I diffed the files and found 57 differences:

* 30: order differences from sorting or not. 
* 2: incorrect `types="x/v7"` references that are now corrected to just `types="x"` by the additional call to `rootName`. I added a test to show that we detect and prevent such references.
* 2: incorrect references "chrome/chromecast" from `types="chrome/chromecast"` are corrected to just "chrome" by the additional call to `rootName`.
* 1: incorrect reference to "@ember/services", from @types/ember__services itself.
* 22: missing references from untested files. I added entries to OTHER_FILES.txt to add these missing references.

There were lots of unused files that I automatically added OTHER_FILES.txt entries for. That's the next step in the process I wrote up at #708.

Note: I *also* need to figure out how to fix the 2 references to `types="x/v7"` which the tests relied on. I think I'll have to add them to the whitelist. =[
Edit: I just updated the tests to newer versions of dependencies: DefinitelyTyped/DefinitelyTyped#40575