### PR TITLE
Add @types/gulp to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -20,6 +20,7 @@
 @types/base-x
 @types/expect
 @types/firebase
+@types/gulp
 @types/highcharts
 @types/hoist-non-react-statics
 @types/next-redux-wrapper


### PR DESCRIPTION
-Sigh- This is needed because gulp-connect still depends on gulp 3.