### PR TITLE
Make filesystem interface synchronous

### DIFF
--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -58,9 +58,9 @@ async function generateTypingPackage(typing: TypingsData, packages: AllPackages,
     await writeCommonOutputs(typing, createPackageJSON(typing, version, packages, Registry.NPM), createReadme(typing, Registry.NPM), Registry.NPM);
     await writeCommonOutputs(typing, createPackageJSON(typing, version, packages, Registry.Github), createReadme(typing, Registry.Github), Registry.Github);
     await Promise.all(
-        typing.files.map(async file => writeFile(await outputFilePath(typing, Registry.NPM, file), await packageFS.readFile(file))));
+        typing.files.map(async file => writeFile(await outputFilePath(typing, Registry.NPM, file), packageFS.readFile(file))));
     await Promise.all(
-        typing.files.map(async file => writeFile(await outputFilePath(typing, Registry.Github, file), await packageFS.readFile(file))));
+        typing.files.map(async file => writeFile(await outputFilePath(typing, Registry.Github, file), packageFS.readFile(file))));
 }
 
 async function generateNotNeededPackage(pkg: NotNeededPackage, client: CachedNpmInfoClient, log: Logger): Promise<void> {

--- a/src/get-definitely-typed.test.ts
+++ b/src/get-definitely-typed.test.ts
@@ -6,8 +6,8 @@ import { testo } from "./util/test";
 testo({
     async downloadDefinitelyTyped() {
         const dt = await getDefinitelyTyped(Options.azure, loggerWithErrors()[0]);
-        expect(await dt.exists("types")).toBe(true);
-        expect(await dt.exists("buncho")).toBe(false);
+        expect(dt.exists("types")).toBe(true);
+        expect(dt.exists("buncho")).toBe(false);
     },
     createDirs() {
         const root = new Dir(undefined);

--- a/src/get-definitely-typed.ts
+++ b/src/get-definitely-typed.ts
@@ -1,6 +1,6 @@
 import appInsights = require("applicationinsights");
 import assert = require("assert");
-import { ensureDir, pathExists, readdir, stat } from "fs-extra";
+import { ensureDir, pathExists, readdir, readdirSync, stat, statSync, pathExistsSync } from "fs-extra";
 import https = require("https");
 import tarStream = require("tar-stream");
 import * as yargs from "yargs";
@@ -8,7 +8,7 @@ import * as zlib from "zlib";
 
 import { Options } from "./lib/common";
 import { dataDirPath, definitelyTypedZipUrl } from "./lib/settings";
-import { readFile, readJson, stringOfStream } from "./util/io";
+import { readFile, readFileSync, readJson, readJsonSync, stringOfStream } from "./util/io";
 import { LoggerWithErrors, loggerWithErrors } from "./util/logging";
 import { assertDefined, assertSorted, Awaitable, exec, joinPaths, logUncaughtErrors, withoutStart } from "./util/util";
 
@@ -22,10 +22,15 @@ export interface FS {
      * If dirPath is missing, reads the root.
      */
     readdir(dirPath?: string): Awaitable<ReadonlyArray<string>>;
+    readdirSync(dirPath?: string): ReadonlyArray<string>;
     readJson(path: string): Awaitable<unknown>;
+    readJsonSync(path: string): unknown;
     readFile(path: string): Awaitable<string>;
+    readFileSync(path: string): string;
     isDirectory(dirPath: string): Awaitable<boolean>;
+    isDirectorySync(dirPath: string): boolean;
     exists(path: string): Awaitable<boolean>;
+    existsSync(path: string): boolean;
     /** FileSystem rooted at a child directory. */
     subDir(path: string): FS;
     /** Representation of current location, for debugging. */
@@ -175,6 +180,14 @@ export class InMemoryDT implements FS {
         return res;
     }
 
+    readFileSync(filePath: string): string {
+        const res = this.getEntry(filePath);
+        if (typeof res !== "string") {
+            throw new Error(`${this.pathToRoot}/${filePath} is a directory, not a file.`);
+        }
+        return res;
+    }
+
     readFile(filePath: string): string {
         const res = this.getEntry(filePath);
         if (typeof res !== "string") {
@@ -187,7 +200,15 @@ export class InMemoryDT implements FS {
         return Array.from((dirPath === undefined ? this.curDir : this.getDir(dirPath)).keys());
     }
 
+    readdirSync(dirPath?: string): ReadonlyArray<string> {
+        return Array.from((dirPath === undefined ? this.curDir : this.getDir(dirPath)).keys());
+    }
+
     readJson(path: string): unknown {
+        return JSON.parse(this.readFile(path)) as unknown;
+    }
+
+    readJsonSync(path: string): unknown {
         return JSON.parse(this.readFile(path)) as unknown;
     }
 
@@ -195,7 +216,15 @@ export class InMemoryDT implements FS {
         return typeof this.getEntry(path) !== "string";
     }
 
+    isDirectorySync(path: string): boolean {
+        return typeof this.getEntry(path) !== "string";
+    }
+
     exists(path: string): boolean {
+        return this.tryGetEntry(path) !== undefined;
+    }
+
+    existsSync(path: string): boolean {
         return this.tryGetEntry(path) !== undefined;
     }
 
@@ -226,20 +255,40 @@ class DiskFS implements FS {
         return assertSorted((await readdir(this.getPath(dirPath))).filter(name => name !== ".DS_STORE"));
     }
 
+    readdirSync(dirPath?: string): ReadonlyArray<string> {
+        return assertSorted(readdirSync(this.getPath(dirPath))).filter(name => name !== ".DS_STORE");
+    }
+
     async isDirectory(dirPath: string): Promise<boolean> {
         return (await stat(this.getPath(dirPath))).isDirectory();
+    }
+
+    isDirectorySync(dirPath: string): boolean {
+        return statSync(this.getPath(dirPath)).isDirectory();
     }
 
     readJson(path: string): Promise<unknown> {
         return readJson(this.getPath(path));
     }
 
+    readJsonSync(path: string): unknown {
+        return readJsonSync(this.getPath(path));
+    }
+
     readFile(path: string): Promise<string> {
         return readFile(this.getPath(path));
     }
 
+    readFileSync(path: string): string {
+        return readFileSync(this.getPath(path));
+    }
+
     exists(path: string): Promise<boolean> {
         return pathExists(this.getPath(path));
+    }
+
+    existsSync(path: string): boolean {
+        return pathExistsSync(this.getPath(path));
     }
 
     subDir(path: string): FS {

--- a/src/lib/definition-parser-worker.ts
+++ b/src/lib/definition-parser-worker.ts
@@ -15,7 +15,7 @@ if (!module.parent) {
         const typesPath = process.argv[2];
         logUncaughtErrors(async () => {
             for (const packageName of message as ReadonlyArray<string>) {
-                const data = await getTypingInfo(packageName, getLocallyInstalledDefinitelyTyped(typesPath).subDir(packageName));
+                const data = getTypingInfo(packageName, getLocallyInstalledDefinitelyTyped(typesPath).subDir(packageName));
                 process.send!({ data, packageName });
             }
         });

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript";
 
 import { FS } from "../get-definitely-typed";
 import {
-    computeHash, filter, flatMap, hasWindowsSlashes, join, mapAsyncOrdered, mapDefined, sort, split, unique, unmangleScopedPackage, withoutStart,
+    computeHash, filter, flatMap, hasWindowsSlashes, join, mapDefined, sort, split, unique, unmangleScopedPackage, withoutStart,
 } from "../util/util";
 
 import { allReferencedFiles, createSourceFile, getModuleInfo, getTestDependencies } from "./module-info";
@@ -11,26 +11,26 @@ import { getLicenseFromPackageJson, PackageId, PackageJsonDependency, PathMappin
 import { dependenciesWhitelist } from "./settings";
 
 /** @param fs Rooted at the package's directory, e.g. `DefinitelyTyped/types/abs` */
-export async function getTypingInfo(packageName: string, fs: FS): Promise<TypingsVersionsRaw> {
+export function getTypingInfo(packageName: string, fs: FS): TypingsVersionsRaw {
     if (packageName !== packageName.toLowerCase()) {
         throw new Error(`Package name \`${packageName}\` should be strictly lowercase`);
     }
     interface OlderVersionDir { readonly directoryName: string; readonly majorVersion: number; }
-    const [rootDirectoryLs, olderVersionDirectories] = split<string, OlderVersionDir>(await fs.readdir(), fileOrDirectoryName => {
+    const [rootDirectoryLs, olderVersionDirectories] = split<string, OlderVersionDir>(fs.readdirSync(), fileOrDirectoryName => {
         const majorVersion = parseMajorVersionFromDirectoryName(fileOrDirectoryName);
         return majorVersion === undefined ? undefined : { directoryName: fileOrDirectoryName, majorVersion };
     });
 
-    const latestData = await combineDataForAllTypesVersions(packageName, rootDirectoryLs, fs, undefined);
+    const latestData = combineDataForAllTypesVersions(packageName, rootDirectoryLs, fs, undefined);
     const latestVersion = latestData.libraryMajorVersion;
 
-    const older = await mapAsyncOrdered(olderVersionDirectories, async ({ directoryName, majorVersion }) => {
+    const older = olderVersionDirectories.map(({ directoryName, majorVersion }) => {
         if (majorVersion === latestVersion) {
             throw new Error(`The latest major version is ${latestVersion}, but a directory v${latestVersion} exists.`);
         }
 
-        const ls = await fs.readdir(directoryName);
-        const data = await combineDataForAllTypesVersions(packageName, ls, fs.subDir(directoryName), majorVersion);
+        const ls = fs.readdirSync(directoryName);
+        const data = combineDataForAllTypesVersions(packageName, ls, fs.subDir(directoryName), majorVersion);
 
         if (data.libraryMajorVersion !== majorVersion) {
             throw new Error(
@@ -74,27 +74,26 @@ export function parseMajorVersionFromDirectoryName(directoryName: string): numbe
     // tslint:disable-next-line no-null-keyword
     return match === null ? undefined : Number(match[1]);
 }
-async function combineDataForAllTypesVersions(
+function combineDataForAllTypesVersions(
     typingsPackageName: string,
     ls: ReadonlyArray<string>,
     fs: FS,
     oldMajorVersion: number | undefined,
-): Promise<TypingsDataRaw> {
+): TypingsDataRaw {
     const { remainingLs, typesVersions, hasPackageJson } = getTypesVersionsAndPackageJson(ls);
 
     // Every typesVersion has an index.d.ts, but only the root index.d.ts should have a header.
     const { contributors, libraryMajorVersion, libraryMinorVersion, typeScriptVersion: minTsVersion, libraryName, projects } =
-        parseHeaderOrFail(await readFileAndThrowOnBOM("index.d.ts", fs));
+        parseHeaderOrFail(readFileAndThrowOnBOM("index.d.ts", fs));
 
-    const dataForRoot = await getTypingDataForSingleTypesVersion(undefined, typingsPackageName, fs.debugPath(), remainingLs, fs, oldMajorVersion);
-    const dataForOtherTypesVersions = await mapAsyncOrdered(typesVersions, async tsVersion => {
+    const dataForRoot = getTypingDataForSingleTypesVersion(undefined, typingsPackageName, fs.debugPath(), remainingLs, fs, oldMajorVersion);
+    const dataForOtherTypesVersions = typesVersions.map(tsVersion => {
         const subFs = fs.subDir(`ts${tsVersion}`);
-        return getTypingDataForSingleTypesVersion(tsVersion, typingsPackageName, fs.debugPath(), await subFs.readdir(), subFs, oldMajorVersion);
+        return getTypingDataForSingleTypesVersion(tsVersion, typingsPackageName, fs.debugPath(), subFs.readdirSync(), subFs, oldMajorVersion);
     });
     const allTypesVersions = [dataForRoot, ...dataForOtherTypesVersions];
 
-    // tslint:disable-next-line await-promise (tslint bug)
-    const packageJson = hasPackageJson ? await fs.readJson(packageJsonName) as { readonly license?: unknown, readonly dependencies?: unknown } : {};
+    const packageJson = hasPackageJson ? fs.readJsonSync(packageJsonName) as { readonly license?: unknown, readonly dependencies?: unknown } : {};
     const license = getLicenseFromPackageJson(packageJson.license);
     const packageJsonDependencies = checkPackageJsonDependencies(packageJson.dependencies, packageJsonName);
 
@@ -118,7 +117,7 @@ async function combineDataForAllTypesVersions(
         testDependencies: getAllUniqueValues<"testDependencies", string>(allTypesVersions, "testDependencies"),
         pathMappings: getAllUniqueValues<"pathMappings", PathMapping>(allTypesVersions, "pathMappings"),
         packageJsonDependencies,
-        contentHash: await hash(hasPackageJson ? [...files, packageJsonName] : files, mapDefined(allTypesVersions, a => a.tsconfigPathsForHash), fs),
+        contentHash: hash(hasPackageJson ? [...files, packageJsonName] : files, mapDefined(allTypesVersions, a => a.tsconfigPathsForHash), fs),
         globals: getAllUniqueValues<"globals", string>(allTypesVersions, "globals"),
         declaredModules: getAllUniqueValues<"declaredModules", string>(allTypesVersions, "declaredModules"),
     };
@@ -146,32 +145,32 @@ interface TypingDataFromIndividualTypeScriptVersion {
  * @param ls All file/directory names in `directory`.
  * @param fs FS rooted at the directory for this particular TS version, e.g. `types/abs/ts3.1` or `types/abs` when typescriptVersion is undefined.
  */
-async function getTypingDataForSingleTypesVersion(
+function getTypingDataForSingleTypesVersion(
     typescriptVersion: TypeScriptVersion | undefined,
     packageName: string,
     packageDirectory: string,
     ls: ReadonlyArray<string>,
     fs: FS,
     oldMajorVersion: number | undefined,
-): Promise<TypingDataFromIndividualTypeScriptVersion> {
-    const tsconfig = await fs.readJson("tsconfig.json") as TsConfig; // tslint:disable-line await-promise (tslint bug)
-    await checkFilesFromTsConfig(packageName, tsconfig, fs.debugPath());
-    const { types, tests } = await allReferencedFiles(tsconfig.files!, fs, packageName, packageDirectory);
+): TypingDataFromIndividualTypeScriptVersion {
+    const tsconfig = fs.readJsonSync("tsconfig.json") as TsConfig;
+    checkFilesFromTsConfig(packageName, tsconfig, fs.debugPath());
+    const { types, tests } = allReferencedFiles(tsconfig.files!, fs, packageName, packageDirectory);
     const usedFiles = new Set([...types.keys(), ...tests.keys(), "tsconfig.json", "tslint.json"]);
-    const otherFiles = ls.indexOf(unusedFilesName) > -1 ? (await fs.readFile(unusedFilesName)).split(/\r?\n/g).filter(Boolean) : [];
-    await checkAllFilesUsed(ls, usedFiles, otherFiles, packageName, fs);
+    const otherFiles = ls.indexOf(unusedFilesName) > -1 ? (fs.readFileSync(unusedFilesName)).split(/\r?\n/g).filter(Boolean) : [];
+    checkAllFilesUsed(ls, usedFiles, otherFiles, packageName, fs);
     for (const untestedTypeFile of filter(otherFiles, name => name.endsWith('.d.ts'))) {
         // add d.ts files from OTHER_FILES.txt in order get their dependencies
-        types.set(untestedTypeFile, createSourceFile(untestedTypeFile, await fs.readFile(untestedTypeFile)));
+        types.set(untestedTypeFile, createSourceFile(untestedTypeFile, fs.readFileSync(untestedTypeFile)));
     }
 
-    const { dependencies: dependenciesWithDeclaredModules, globals, declaredModules } = await getModuleInfo(packageName, types);
+    const { dependencies: dependenciesWithDeclaredModules, globals, declaredModules } = getModuleInfo(packageName, types);
     const declaredModulesSet = new Set(declaredModules);
     // Don't count an import of "x" as a dependency if we saw `declare module "x"` somewhere.
     const dependenciesSet = new Set(filter(dependenciesWithDeclaredModules, m => !declaredModulesSet.has(m)));
-    const testDependencies = Array.from(filter(await getTestDependencies(packageName, types, tests.keys(), dependenciesSet, fs), m => !declaredModulesSet.has(m)));
+    const testDependencies = Array.from(filter(getTestDependencies(packageName, types, tests.keys(), dependenciesSet, fs), m => !declaredModulesSet.has(m)));
 
-    const { dependencies, pathMappings } = await calculateDependencies(packageName, tsconfig, dependenciesSet, oldMajorVersion);
+    const { dependencies, pathMappings } = calculateDependencies(packageName, tsconfig, dependenciesSet, oldMajorVersion);
     const tsconfigPathsForHash = JSON.stringify(tsconfig.compilerOptions.paths);
     return { typescriptVersion, dependencies, testDependencies, pathMappings, globals, declaredModules, declFiles: sort(types.keys()), tsconfigPathsForHash };
 }
@@ -213,7 +212,7 @@ If this is an external library that provides typings,  please make a pull reques
     return deps;
 }
 
-async function checkFilesFromTsConfig(packageName: string, tsconfig: TsConfig, directoryPath: string): Promise<void> {
+function checkFilesFromTsConfig(packageName: string, tsconfig: TsConfig, directoryPath: string): void {
     const tsconfigPath = `${directoryPath}/tsconfig.json`;
     if (tsconfig.include) {
         throw new Error(`In tsconfig, don't use "include", must use "files"`);
@@ -252,12 +251,12 @@ interface TsConfig {
 
 /** In addition to dependencies found in source code, also get dependencies from tsconfig. */
 interface DependenciesAndPathMappings { readonly dependencies: ReadonlyArray<PackageId>; readonly pathMappings: ReadonlyArray<PathMapping>; }
-async function calculateDependencies(
+function calculateDependencies(
     packageName: string,
     tsconfig: TsConfig,
     dependencyNames: ReadonlySet<string>,
     oldMajorVersion: number | undefined,
-): Promise<DependenciesAndPathMappings> {
+): DependenciesAndPathMappings {
     const paths = tsconfig.compilerOptions && tsconfig.compilerOptions.paths || {};
 
     const dependencies: PackageId[] = [];
@@ -342,8 +341,8 @@ function withoutEnd(s: string, end: string): string | undefined {
     return undefined;
 }
 
-async function hash(files: ReadonlyArray<string>, tsconfigPathsForHash: ReadonlyArray<string>, fs: FS): Promise<string> {
-    const fileContents = await mapAsyncOrdered(files, async f => `${f}**${await readFileAndThrowOnBOM(f, fs)}`);
+function hash(files: ReadonlyArray<string>, tsconfigPathsForHash: ReadonlyArray<string>, fs: FS): string {
+    const fileContents = files.map(f => `${f}**${readFileAndThrowOnBOM(f, fs)}`);
     let allContent = fileContents.join("||");
     for (const path of tsconfigPathsForHash) {
         allContent += path;
@@ -351,8 +350,8 @@ async function hash(files: ReadonlyArray<string>, tsconfigPathsForHash: Readonly
     return computeHash(allContent);
 }
 
-export async function readFileAndThrowOnBOM(fileName: string, fs: FS): Promise<string> {
-    const text = await fs.readFile(fileName);
+export function readFileAndThrowOnBOM(fileName: string, fs: FS): string {
+    const text = fs.readFileSync(fileName);
     if (text.charCodeAt(0) === 0xFEFF) {
         const commands = [
             "npm install -g strip-bom-cli",
@@ -366,17 +365,17 @@ export async function readFileAndThrowOnBOM(fileName: string, fs: FS): Promise<s
 
 const unusedFilesName = "OTHER_FILES.txt";
 
-async function checkAllFilesUsed(ls: ReadonlyArray<string>, usedFiles: Set<string>, otherFiles: string[], packageName: string, fs: FS): Promise<void> {
+function checkAllFilesUsed(ls: ReadonlyArray<string>, usedFiles: Set<string>, otherFiles: string[], packageName: string, fs: FS): void {
     // Double-check that no windows "\\" broke in.
     for (const fileName of usedFiles) {
         if (hasWindowsSlashes(fileName)) {
             throw new Error(`In ${packageName}: windows slash detected in ${fileName}`);
         }
     }
-    await checkAllUsedRecur(new Set(ls), usedFiles,  new Set(otherFiles), fs);
+    checkAllUsedRecur(new Set(ls), usedFiles,  new Set(otherFiles), fs);
 }
 
-async function checkAllUsedRecur(ls: Iterable<string>, usedFiles: Set<string>, unusedFiles: Set<string>, fs: FS): Promise<void> {
+function checkAllUsedRecur(ls: Iterable<string>, usedFiles: Set<string>, unusedFiles: Set<string>, fs: FS): void {
     for (const lsEntry of ls) {
         if (usedFiles.has(lsEntry)) {
             continue;
@@ -386,14 +385,14 @@ async function checkAllUsedRecur(ls: Iterable<string>, usedFiles: Set<string>, u
             continue;
         }
 
-        if (await fs.isDirectory(lsEntry)) {
+        if (fs.isDirectorySync(lsEntry)) {
             const subdir = fs.subDir(lsEntry);
             // We allow a "scripts" directory to be used for scripts.
             if (lsEntry === "node_modules" || lsEntry === "scripts") {
                 continue;
             }
 
-            const lssubdir = await subdir.readdir();
+            const lssubdir = subdir.readdirSync();
             if (lssubdir.length === 0) {
                 throw new Error(`Empty directory ${subdir} (${join(usedFiles)})`);
             }
@@ -409,7 +408,7 @@ async function checkAllUsedRecur(ls: Iterable<string>, usedFiles: Set<string>, u
                 }
                 return subdirSet;
             }
-            await checkAllUsedRecur(lssubdir, takeSubdirectoryOutOfSet(usedFiles), takeSubdirectoryOutOfSet(unusedFiles), subdir);
+            checkAllUsedRecur(lssubdir, takeSubdirectoryOutOfSet(usedFiles), takeSubdirectoryOutOfSet(unusedFiles), subdir);
         } else {
             if (lsEntry.toLowerCase() !== "readme.md" && lsEntry !== "NOTICE" && lsEntry !== ".editorconfig" && lsEntry !== unusedFilesName) {
                 throw new Error(`Unused file ${fs.debugPath()}/${lsEntry} (used files: ${JSON.stringify(Array.from(usedFiles))})`);

--- a/src/lib/module-info.test.ts
+++ b/src/lib/module-info.test.ts
@@ -4,44 +4,44 @@ import { testo } from "../util/test";
 import { createMockDT } from "../mocks"
 import * as ts from 'typescript'
 const fs = createMockDT();
-async function getBoringReferences() {
+function getBoringReferences() {
     return allReferencedFiles(["index.d.ts", "boring-tests.ts"], fs.subDir("types").subDir("boring"), "boring", "types/boring")
 }
 testo({
-    async allReferencedFilesFromTsconfigFiles() {
-        const { types, tests } = await getBoringReferences();
-        expect(Array.from(types.keys())).toEqual(["index.d.ts", "secondary.d.ts", "commonjs.d.ts", "v1.d.ts", "quaternary.d.ts", "tertiary.d.ts"])
+    allReferencedFilesFromTsconfigFiles() {
+        const { types, tests } = getBoringReferences();
+        expect(Array.from(types.keys())).toEqual(["index.d.ts", "secondary.d.ts", "quaternary.d.ts", "tertiary.d.ts", "commonjs.d.ts", "v1.d.ts"])
         expect(Array.from(tests.keys())).toEqual(["boring-tests.ts"])
     },
-    async allReferencedFilesFromTestIncludesSecondaryInternalFiles() {
-        const { types, tests } = await allReferencedFiles(["boring-tests.ts"], fs.subDir("types").subDir("boring"), "boring", "types/boring")
-        expect(Array.from(types.keys())).toEqual(["secondary.d.ts", "commonjs.d.ts", "v1.d.ts", "quaternary.d.ts", "tertiary.d.ts"])
+    allReferencedFilesFromTestIncludesSecondaryInternalFiles() {
+        const { types, tests } = allReferencedFiles(["boring-tests.ts"], fs.subDir("types").subDir("boring"), "boring", "types/boring")
+        expect(Array.from(types.keys())).toEqual(["secondary.d.ts", "quaternary.d.ts", "tertiary.d.ts", "commonjs.d.ts", "v1.d.ts"])
         expect(Array.from(tests.keys())).toEqual(["boring-tests.ts"])
     },
-    async allReferencedFilesFromTsconfigGlobal() {
-        const { types, tests } = await allReferencedFiles(["jquery-tests.ts", "index.d.ts"], fs.subDir("types").subDir("jquery"), "jquery", "types/jquery")
+    allReferencedFilesFromTsconfigGlobal() {
+        const { types, tests } = allReferencedFiles(["jquery-tests.ts", "index.d.ts"], fs.subDir("types").subDir("jquery"), "jquery", "types/jquery")
         expect(Array.from(types.keys())).toEqual(["index.d.ts", "JQuery.d.ts"])
         expect(Array.from(tests.keys())).toEqual(["jquery-tests.ts"])
     },
-    async allReferencedFilesFromTestIncludesSecondaryTripleSlashTypes() {
-        const { types, tests } = await allReferencedFiles(["globby-tests.ts", "test/other-tests.ts"], fs.subDir("types").subDir("globby"), "globby", "types/globby")
+    allReferencedFilesFromTestIncludesSecondaryTripleSlashTypes() {
+        const { types, tests } = allReferencedFiles(["globby-tests.ts", "test/other-tests.ts"], fs.subDir("types").subDir("globby"), "globby", "types/globby")
         expect(Array.from(types.keys())).toEqual(["merges.d.ts"])
         expect(Array.from(tests.keys())).toEqual(["globby-tests.ts", "test/other-tests.ts"])
     },
-    async getModuleInfoWorksWithOtherFiles() {
-        const { types } = await getBoringReferences();
+    getModuleInfoWorksWithOtherFiles() {
+        const { types } = getBoringReferences();
         // written as if it were from OTHER_FILES.txt
-        types.set("untested.d.ts", ts.createSourceFile("untested.d.ts", await fs.subDir("types").subDir("boring").readFile("untested.d.ts"), ts.ScriptTarget.Latest, false));
-        const i = await getModuleInfo("boring", types);
+        types.set("untested.d.ts", ts.createSourceFile("untested.d.ts", fs.subDir("types").subDir("boring").readFileSync("untested.d.ts"), ts.ScriptTarget.Latest, false));
+        const i = getModuleInfo("boring", types);
         expect(i.dependencies).toEqual(new Set(['manual', 'react', 'react-default', 'things', 'vorticon']));
     },
-    async getModuleInfoForNestedTypeReferences() {
-        const { types } = await allReferencedFiles(["index.d.ts", "globby-tests.ts", "test/other-tests.ts"], fs.subDir("types").subDir("globby"), "globby", "types/globby")
+    getModuleInfoForNestedTypeReferences() {
+        const { types } = allReferencedFiles(["index.d.ts", "globby-tests.ts", "test/other-tests.ts"], fs.subDir("types").subDir("globby"), "globby", "types/globby")
         expect(Array.from(types.keys())).toEqual(["index.d.ts", "sneaky.d.ts", "merges.d.ts"])
-        const i = await getModuleInfo("globby", types);
+        const i = getModuleInfo("globby", types);
         expect(i.dependencies).toEqual(new Set(['andere']));
     },
-    async versionTypeRefThrows() {
+    versionTypeRefThrows() {
         const fail = new Dir(undefined);
         const fs = new InMemoryDT(fail, "typeref-fails");
         fail.set("index.d.ts", `// Type definitions for fail 1.0
@@ -51,14 +51,14 @@ testo({
 
 /// <reference types="elser/v3" />
 `);
-        const { types } = await allReferencedFiles(["index.d.ts"], fs, "typeref-fails", "types/typeref-fails")
+        const { types } = allReferencedFiles(["index.d.ts"], fs, "typeref-fails", "types/typeref-fails")
         expect(Array.from(types.keys())).toEqual(["index.d.ts"])
-        await expect(getModuleInfo("typeref-fails", types)).rejects.toThrow("do not directly import specific versions of another types package");
+        expect(() => getModuleInfo("typeref-fails", types)).toThrow("do not directly import specific versions of another types package");
     },
-    async getTestDependenciesWorks() {
-        const { types, tests } = await getBoringReferences();
-        const i = await getModuleInfo("boring", types);
-        const d = await getTestDependencies("boring", types, tests.keys(), i.dependencies, fs.subDir("types").subDir("boring"));
+    getTestDependenciesWorks() {
+        const { types, tests } = getBoringReferences();
+        const i = getModuleInfo("boring", types);
+        const d = getTestDependencies("boring", types, tests.keys(), i.dependencies, fs.subDir("types").subDir("boring"));
         expect(d).toEqual(new Set(["super-big-fun-hus"]));
     },
 })

--- a/src/lib/module-info.test.ts
+++ b/src/lib/module-info.test.ts
@@ -31,7 +31,7 @@ testo({
     getModuleInfoWorksWithOtherFiles() {
         const { types } = getBoringReferences();
         // written as if it were from OTHER_FILES.txt
-        types.set("untested.d.ts", ts.createSourceFile("untested.d.ts", fs.subDir("types").subDir("boring").readFileSync("untested.d.ts"), ts.ScriptTarget.Latest, false));
+        types.set("untested.d.ts", ts.createSourceFile("untested.d.ts", fs.subDir("types").subDir("boring").readFile("untested.d.ts"), ts.ScriptTarget.Latest, false));
         const i = getModuleInfo("boring", types);
         expect(i.dependencies).toEqual(new Set(['manual', 'react', 'react-default', 'things', 'vorticon']));
     },

--- a/src/lib/module-info.ts
+++ b/src/lib/module-info.ts
@@ -158,7 +158,7 @@ export function allReferencedFiles(
         seenReferences.add(text);
 
         const resolvedFilename = exact ? text : resolveModule(text, fs);
-        if (fs.existsSync(resolvedFilename)) {
+        if (fs.exists(resolvedFilename)) {
             const src = createSourceFile(resolvedFilename, readFileAndThrowOnBOM(resolvedFilename, fs));
             if (resolvedFilename.endsWith(".d.ts")) {
                 types.set(resolvedFilename, src);
@@ -176,11 +176,11 @@ export function allReferencedFiles(
 function resolveModule(importSpecifier: string, fs: FS): string {
     importSpecifier = importSpecifier.endsWith("/") ? importSpecifier.slice(0, importSpecifier.length - 1) : importSpecifier;
     if (importSpecifier !== "." && importSpecifier !== "..") {
-        if (fs.existsSync(importSpecifier + ".d.ts")) {
+        if (fs.exists(importSpecifier + ".d.ts")) {
             return importSpecifier + ".d.ts";
-        } else if (fs.existsSync(importSpecifier + ".ts")) {
+        } else if (fs.exists(importSpecifier + ".ts")) {
             return importSpecifier + ".ts";
-        } else if (fs.existsSync(importSpecifier + ".tsx")) {
+        } else if (fs.exists(importSpecifier + ".tsx")) {
             return importSpecifier + ".tsx";
         }
     }

--- a/src/lib/module-info.ts
+++ b/src/lib/module-info.ts
@@ -7,7 +7,7 @@ import { hasWindowsSlashes, joinPaths, normalizeSlashes, sort } from "../util/ut
 
 import { readFileAndThrowOnBOM } from "./definition-parser";
 
-export async function getModuleInfo(packageName: string, all: Map<string, ts.SourceFile>): Promise<ModuleInfo> {
+export function getModuleInfo(packageName: string, all: Map<string, ts.SourceFile>): ModuleInfo {
 
     const dependencies = new Set<string>();
     const declaredModules: string[] = [];
@@ -142,24 +142,24 @@ function withoutExtension(str: string, ext: string): string {
 }
 
 /** Returns a map from filename (path relative to `directory`) to the SourceFile we parsed for it. */
-export async function allReferencedFiles(
+export function allReferencedFiles(
     entryFilenames: ReadonlyArray<string>, fs: FS, packageName: string, baseDirectory: string
-): Promise<{ types: Map<string, ts.SourceFile>, tests: Map<string, ts.SourceFile> }> {
+): { types: Map<string, ts.SourceFile>, tests: Map<string, ts.SourceFile> } {
     const seenReferences = new Set<string>();
     const types = new Map<string, ts.SourceFile>();
     const tests = new Map<string, ts.SourceFile>();
-    await Promise.all(entryFilenames.map(text => recur({ text, exact: true })));
+    entryFilenames.forEach(text => recur({ text, exact: true }));
     return { types, tests };
 
-    async function recur({ text, exact }: Reference): Promise<void> {
+    function recur({ text, exact }: Reference): void {
         if (seenReferences.has(text)) {
             return;
         }
         seenReferences.add(text);
 
-        const resolvedFilename = exact ? text : await resolveModule(text, fs);
-        if (await fs.exists(resolvedFilename)) {
-            const src = createSourceFile(resolvedFilename, await readFileAndThrowOnBOM(resolvedFilename, fs));
+        const resolvedFilename = exact ? text : resolveModule(text, fs);
+        if (fs.existsSync(resolvedFilename)) {
+            const src = createSourceFile(resolvedFilename, readFileAndThrowOnBOM(resolvedFilename, fs));
             if (resolvedFilename.endsWith(".d.ts")) {
                 types.set(resolvedFilename, src);
             } else {
@@ -167,20 +167,20 @@ export async function allReferencedFiles(
             }
 
             const refs = findReferencedFiles(src, packageName, path.dirname(resolvedFilename), normalizeSlashes(path.relative(baseDirectory, fs.debugPath())));
-            await Promise.all(refs.map(recur));
+            refs.forEach(recur);
         }
     }
 
 }
 
-async function resolveModule(importSpecifier: string, fs: FS): Promise<string> {
+function resolveModule(importSpecifier: string, fs: FS): string {
     importSpecifier = importSpecifier.endsWith("/") ? importSpecifier.slice(0, importSpecifier.length - 1) : importSpecifier;
     if (importSpecifier !== "." && importSpecifier !== "..") {
-        if (await fs.exists(importSpecifier + ".d.ts")) {
+        if (fs.existsSync(importSpecifier + ".d.ts")) {
             return importSpecifier + ".d.ts";
-        } else if (await fs.exists(importSpecifier + ".ts")) {
+        } else if (fs.existsSync(importSpecifier + ".ts")) {
             return importSpecifier + ".ts";
-        } else if (await fs.exists(importSpecifier + ".tsx")) {
+        } else if (fs.existsSync(importSpecifier + ".tsx")) {
             return importSpecifier + ".tsx";
         }
     }
@@ -333,16 +333,16 @@ function assertNoWindowsSlashes(packageName: string, fileName: string): string {
     return fileName;
 }
 
-export async function getTestDependencies(
+export function getTestDependencies(
     packageName: string,
     typeFiles: Map<string, unknown>,
     testFiles: Iterable<string>,
     dependencies: ReadonlySet<string>,
     fs: FS,
-): Promise<Iterable<string>> {
+): Iterable<string> {
     const testDependencies = new Set<string>();
     for (const filename of testFiles) {
-        const content = await readFileAndThrowOnBOM(filename, fs);
+        const content = readFileAndThrowOnBOM(filename, fs);
         const sourceFile = createSourceFile(filename, content);
         const { fileName, referencedFiles, typeReferenceDirectives } = sourceFile;
         const filePath = () => path.join(packageName, fileName);

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -10,7 +10,7 @@ import { Semver } from "./versions";
 
 export class AllPackages {
     static async read(dt: FS): Promise<AllPackages> {
-        return AllPackages.from(await readTypesDataFile(), await readNotNeededPackages(dt));
+        return AllPackages.from(await readTypesDataFile(), readNotNeededPackages(dt));
     }
 
     static from(data: TypesDataFile, notNeeded: ReadonlyArray<NotNeededPackage>): AllPackages {
@@ -38,8 +38,8 @@ export class AllPackages {
         return new TypingsData(raw[versions[0]], /*isLatest*/ true);
     }
 
-    static async readSingleNotNeeded(name: string, dt: FS): Promise<NotNeededPackage> {
-        const notNeeded = await readNotNeededPackages(dt);
+    static readSingleNotNeeded(name: string, dt: FS): NotNeededPackage {
+        const notNeeded = readNotNeededPackages(dt);
         const pkg = notNeeded.find(p => p.name === name);
         if (pkg === undefined) {
             throw new Error(`Cannot find not-needed package ${name}`);
@@ -454,7 +454,7 @@ function readTypesDataFile(): Promise<TypesDataFile> {
     return readDataFile("parse-definitions", typesDataFilename) as Promise<TypesDataFile>;
 }
 
-export async function readNotNeededPackages(dt: FS): Promise<ReadonlyArray<NotNeededPackage>> {
-    const rawJson = await dt.readJson("notNeededPackages.json"); // tslint:disable-line await-promise (tslint bug)
+export function readNotNeededPackages(dt: FS): ReadonlyArray<NotNeededPackage> {
+    const rawJson = dt.readJson("notNeededPackages.json"); // tslint:disable-line await-promise (tslint bug)
     return (rawJson as { readonly packages: ReadonlyArray<NotNeededPackageRaw> }).packages.map(raw => new NotNeededPackage(raw));
 }

--- a/src/parse-definitions.ts
+++ b/src/parse-definitions.ts
@@ -52,7 +52,7 @@ export default async function parseDefinitions(dt: FS, parallel: ParallelOptions
     } else {
         log.info("Parsing non-parallel...");
         for (const packageName of packageNames) {
-            typings[packageName] = await getTypingInfo(packageName, typesFS.subDir(packageName));
+            typings[packageName] = getTypingInfo(packageName, typesFS.subDir(packageName));
         }
     }
     log.info("Parsing took " + ((Date.now() - start) / 1000) + " s");
@@ -69,7 +69,7 @@ function sorted<T>(obj: { [name: string]: T }): { [name: string]: T } {
 }
 
 async function single(singleName: string, dt: FS): Promise<void> {
-    const data = await getTypingInfo(singleName, dt.subDir("types").subDir(singleName));
+    const data = getTypingInfo(singleName, dt.subDir("types").subDir(singleName));
     const typings = { [singleName]: data };
     await writeDataFile(typesDataFilename, typings);
     console.log(JSON.stringify(data, undefined, 4));

--- a/src/parse-definitions.ts
+++ b/src/parse-definitions.ts
@@ -32,7 +32,7 @@ export interface ParallelOptions { readonly nProcesses: number; readonly definit
 export default async function parseDefinitions(dt: FS, parallel: ParallelOptions | undefined, log: LoggerWithErrors): Promise<AllPackages> {
     log.info("Parsing definitions...");
     const typesFS = dt.subDir("types");
-    const packageNames = await filterNAtATimeOrdered(parallel ? parallel.nProcesses : 1, await typesFS.readdir(), name => typesFS.isDirectory(name));
+    const packageNames = await filterNAtATimeOrdered(parallel ? parallel.nProcesses : 1, typesFS.readdir(), name => typesFS.isDirectory(name));
     log.info(`Found ${packageNames.length} packages.`);
 
     const typings: { [name: string]: TypingsVersionsRaw } = {};
@@ -57,7 +57,7 @@ export default async function parseDefinitions(dt: FS, parallel: ParallelOptions
     }
     log.info("Parsing took " + ((Date.now() - start) / 1000) + " s");
     await writeDataFile(typesDataFilename, sorted(typings));
-    return AllPackages.from(typings, await readNotNeededPackages(dt));
+    return AllPackages.from(typings, readNotNeededPackages(dt));
 }
 
 function sorted<T>(obj: { [name: string]: T }): { [name: string]: T } {

--- a/src/publish-packages.ts
+++ b/src/publish-packages.ts
@@ -23,13 +23,13 @@ if (!module.parent) {
             const log = logger()[0];
             try {
                 await deprecateNotNeededPackage(
-                    await NpmPublishClient.create(), await AllPackages.readSingleNotNeeded(deprecateName, dt), /*dry*/ false, log, Registry.Github);
+                    await NpmPublishClient.create(), AllPackages.readSingleNotNeeded(deprecateName, dt), /*dry*/ false, log, Registry.Github);
             } catch(e) {
                 // log and continue
                 log("publishing to github failed: " + e.toString());
             }
             await deprecateNotNeededPackage(
-                await NpmPublishClient.create(), await AllPackages.readSingleNotNeeded(deprecateName, dt), /*dry*/ false, log, Registry.NPM);
+                await NpmPublishClient.create(), AllPackages.readSingleNotNeeded(deprecateName, dt), /*dry*/ false, log, Registry.NPM);
         } else {
             await publishPackages(await readChangedPackages(await AllPackages.read(dt)), dry, process.env.GH_API_TOKEN || "", new Fetcher());
         }

--- a/src/util/io.ts
+++ b/src/util/io.ts
@@ -1,4 +1,4 @@
-import { readFile as readFileWithEncoding, stat, writeFile as writeFileWithEncoding, writeJson as writeJsonRaw } from "fs-extra";
+import { readFile as readFileWithEncoding, readFileSync as readFileWithEncodingSync, stat, writeFile as writeFileWithEncoding, writeJson as writeJsonRaw } from "fs-extra";
 import { request as httpRequest } from "http";
 import { Agent, request } from "https";
 import { Readable as ReadableStream } from "stream";
@@ -12,6 +12,18 @@ export async function readFile(path: string): Promise<string> {
         throw new Error(`Bad character in ${path}`);
     }
     return res;
+}
+
+export function readFileSync(path: string): string {
+    const res = readFileWithEncodingSync(path, { encoding: "utf8" });
+    if (res.includes("�")) {
+        throw new Error(`Bad character in ${path}`);
+    }
+    return res;
+}
+
+export function readJsonSync(path: string): object {
+    return parseJson(readFileSync(path));
 }
 
 export async function readJson(path: string): Promise<object> {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -89,14 +89,6 @@ export async function filterNAtATimeOrdered<T>(
     return inputs.filter((_, idx) => shouldKeeps[idx]);
 }
 
-export async function mapAsyncOrdered<T, U>(arr: ReadonlyArray<T>, mapper: (t: T) => Promise<U>): Promise<U[]> {
-    const out = new Array(arr.length);
-    await Promise.all(arr.map(async (em, idx) => {
-        out[idx] = await mapper(em);
-    }));
-    return out;
-}
-
 export function unique<T>(arr: Iterable<T>): T[] {
     return [...new Set(arr)];
 }


### PR DESCRIPTION
In definition-parser and module-info, this provides about a 25% speedup on my machine. I expect gains to be smaller on slower machines since the time taken to run should be relatively larger than the overhead of async.

The overall ability for parallelism remains, implemented by forking separate processes and having them communicate. This just removes fine-grained parallelism via asynchrony during filesystem operations.

It also makes debugging module-info much easier, and the order of parsing deterministic. And there's less code overall.

The only place I would expect to be slower is in generate-packages, when copying files from Definitely Typed to the package just before publishing. But this only runs 5 times per package on average and a few hundred times in the biggest packages. So I don't think making the read synchronous will kill publishing performance, which is a background process anyway.