### PR TITLE
Use CRLF everywhere

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1784,7 +1784,7 @@
         "request": "^2.88.0",
         "strip-json-comments": "^2.0.1",
         "tslint": "5.14.0",
-        "typescript": "^3.8.0-dev.20191030"
+        "typescript": "^3.8.0-dev.20191212"
       },
       "dependencies": {
         "fs-extra": {
@@ -9288,9 +9288,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.8.0-dev.20191030",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20191030.tgz",
-      "integrity": "sha512-H4ICJQz3KmUy1V7MyBK+YjTDNTHPGuSIbCYxgJbhn/klrgs2P3jBuuS9neb5hpRNe4WU+dtXzPbfrl19czJgiw=="
+      "version": "3.8.0-dev.20191212",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20191212.tgz",
+      "integrity": "sha512-fIxJcBYMqhuep+fYNBmCYT9HjAYS5Dajdgr33p/v+m4DdpOIRh0TJ9NmT0e3NB0Bq1VB12sOi8P/VMPIbWNmGw=="
     },
     "uglify-js": {
       "version": "3.6.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
         "outDir": "bin",
         "sourceMap": true,
         "target": "es2017",
+        "newLine": "crlf",
 
         "baseUrl": ".",
         "paths": {


### PR DESCRIPTION
On osx when you build it makes a massive diff due to line endings, I'm not tied to unix endings everywhere (if you are we can change) but this at least makes it consistent.