### PR TITLE
Support majors as minors in folders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,19 @@ branches:
 
 install:
   - npm ci
+  - git clone https://github.com/DefinitelyTyped/DefinitelyTyped ../DefinitelyTyped
+
+script:
+  - npm test
+  
+  - npm run build
+  - npm run clean
+  - npm run parse
+  - npm run check
+  - npm run calculate-versions
+  - npm run generate
+  - npm run index
+
 
 git:
   depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 
+ cache:
+    directories:
+     - cache/
+
 node_js:
   - 'node'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: node_js
 
- cache:
-    directories:
-     - cache/
-
 node_js:
   - 'node'
+
+cache:
+  directories:
+    - cache/
 
 sudo: false
 
@@ -18,16 +18,11 @@ install:
   - git clone https://github.com/DefinitelyTyped/DefinitelyTyped ../DefinitelyTyped
 
 script:
-  - npm test
-  
+  - npm tes
   - npm run build
   - npm run clean
   - npm run parse
   - npm run check
-  - npm run calculate-versions
-  - npm run generate
-  - npm run index
-
 
 git:
   depth: 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1784,7 +1784,7 @@
         "request": "^2.88.0",
         "strip-json-comments": "^2.0.1",
         "tslint": "5.14.0",
-        "typescript": "^3.8.0-dev.20191030"
+        "typescript": "^3.8.0-dev.20191212"
       },
       "dependencies": {
         "fs-extra": {
@@ -9288,9 +9288,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.8.0-dev.20191030",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20191030.tgz",
-      "integrity": "sha512-H4ICJQz3KmUy1V7MyBK+YjTDNTHPGuSIbCYxgJbhn/klrgs2P3jBuuS9neb5hpRNe4WU+dtXzPbfrl19czJgiw=="
+      "version": "3.8.0-dev.20191212",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20191212.tgz",
+      "integrity": "sha512-fIxJcBYMqhuep+fYNBmCYT9HjAYS5Dajdgr33p/v+m4DdpOIRh0TJ9NmT0e3NB0Bq1VB12sOi8P/VMPIbWNmGw=="
     },
     "uglify-js": {
       "version": "3.6.4",

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -52,7 +52,10 @@ export function getTypingInfo(packageName: string, fs: FS): TypingsVersionsRaw {
     const res: TypingsVersionsRaw = {};
     res[latestVersion] = latestData;
     for (const o of older) {
-        res[o.libraryMajorVersion + "." + o.libraryMinorVersion] = o;
+        const isZeroPointRelease = o.libraryMajorVersion === 0;
+        const isZero = isZeroPointRelease && o.libraryMinorVersion === 0;
+        const tag = !isZeroPointRelease ? o.libraryMajorVersion : isZero ? "0" : o.libraryMinorVersion;
+        res[tag] = o;
     }
     return res;
 }

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -397,7 +397,7 @@ class TypingsVersions {
     private getExact(majorVersion: number): TypingsData {
         const data = this.tryGetExact(majorVersion);
         if (!data) {
-            throw new Error(`Could not find version ${majorVersion}`);
+            throw new Error(`Could not find version ${majorVersion}, found: ${Array.from(this.map).join(", ")}`);
         }
         return data;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
         "outDir": "bin",
         "sourceMap": true,
         "target": "es2017",
+        "newLine": "crlf",
 
         "baseUrl": ".",
         "paths": {


### PR DESCRIPTION
I ended up an hour or two deep into my first shot at this by trying to support "x.y" versions. This... became a massive refactor which I became less confident in as I dug deeper.

The tricky thing with supporting x.y versions internally is that it _has_ to be mapped to a string otherwise you lose `0.60`, or `0.0` in the conversion to a number. Now suddenly a lot of places are going to move to validating both minor and major, and there's the number coercion for comparisons etc. It got a bit rough.

This instead  does not raise when using a minor version as a major when the initial version is 0. Allowing someone with `0.61` to set a folder as `v61` and it to be 🆗 

My setup for some reason isn't letting me do a full parse on a clean compile, so I'm hoping CI will validate it here

re: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/40923