### PR TITLE
Move github publishing to @types

### DIFF
--- a/src/generate-packages.test.ts
+++ b/src/generate-packages.test.ts
@@ -50,23 +50,19 @@ testo({
     },
     basicReadme() {
         const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(createReadme(typing, Registry.NPM)).toEqual(expect.stringContaining("This package contains type definitions for"));
-    },
-    githubReadme() {
-        const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(createReadme(typing, Registry.Github)).toEqual(expect.stringContaining("npm install --save @testtypepublishing/"));
+        expect(createReadme(typing)).toEqual(expect.stringContaining("This package contains type definitions for"));
     },
     readmeContainsProjectName() {
         const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(createReadme(typing, Registry.NPM)).toEqual(expect.stringContaining("jquery.org"));
+        expect(createReadme(typing)).toEqual(expect.stringContaining("jquery.org"));
     },
     readmeNoDependencies() {
         const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(createReadme(typing, Registry.NPM)).toEqual(expect.stringContaining("Dependencies: none"));
+        expect(createReadme(typing)).toEqual(expect.stringContaining("Dependencies: none"));
     },
     readmeNoGlobals() {
         const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(createReadme(typing, Registry.NPM)).toEqual(expect.stringContaining("Global values: none"));
+        expect(createReadme(typing)).toEqual(expect.stringContaining("Global values: none"));
     },
     async basicPackageJson() {
         const packages = AllPackages.from(createTypesData(), await readNotNeededPackages(createMockDT()));
@@ -100,7 +96,7 @@ testo({
         const packages = AllPackages.from(createTypesData(), await readNotNeededPackages(createMockDT()));
         const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
         expect(createPackageJSON(typing, "1.0", packages, Registry.Github)).toEqual(
-            expect.stringContaining('"name": "@testtypepublishing/jquery"'));
+            expect.stringContaining('"name": "@types/jquery"'));
     },
     async githubPackageJsonRegistry() {
         const packages = AllPackages.from(createTypesData(), await readNotNeededPackages(createMockDT()));
@@ -128,7 +124,7 @@ testo({
     },
     async githubNotNeededPackageJson() {
         const s = createNotNeededPackageJSON(createUnneededPackage(), Registry.Github);
-        expect(s).toEqual(expect.stringContaining('@testtypepublishing'));
+        expect(s).toEqual(expect.stringContaining('@types'));
         expect(s).toEqual(expect.stringContaining('npm.pkg.github.com'));
     },
 });

--- a/src/generate-packages.test.ts
+++ b/src/generate-packages.test.ts
@@ -95,13 +95,13 @@ testo({
     async githubPackageJsonName() {
         const packages = AllPackages.from(createTypesData(), await readNotNeededPackages(createMockDT()));
         const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
-        expect(createPackageJSON(typing, "1.0", packages, Registry.Github)).toEqual(
+        expect(createPackageJSON(typing, "1.0", packages, Registry.GithubPackages)).toEqual(
             expect.stringContaining('"name": "@types/jquery"'));
     },
     async githubPackageJsonRegistry() {
         const packages = AllPackages.from(createTypesData(), await readNotNeededPackages(createMockDT()));
         const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
-        const s = createPackageJSON(typing, "1.0", packages, Registry.Github);
+        const s = createPackageJSON(typing, "1.0", packages, Registry.GithubPackages);
         expect(s).toEqual(expect.stringContaining('publishConfig'));
         expect(s).toEqual(expect.stringContaining('"registry": "https://npm.pkg.github.com/"'));
     },
@@ -123,7 +123,7 @@ testo({
 }`);
     },
     async githubNotNeededPackageJson() {
-        const s = createNotNeededPackageJSON(createUnneededPackage(), Registry.Github);
+        const s = createNotNeededPackageJSON(createUnneededPackage(), Registry.GithubPackages);
         expect(s).toEqual(expect.stringContaining('@types'));
         expect(s).toEqual(expect.stringContaining('npm.pkg.github.com'));
     },

--- a/src/generate-packages.test.ts
+++ b/src/generate-packages.test.ts
@@ -95,13 +95,13 @@ testo({
     async githubPackageJsonName() {
         const packages = AllPackages.from(createTypesData(), await readNotNeededPackages(createMockDT()));
         const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
-        expect(createPackageJSON(typing, "1.0", packages, Registry.GithubPackages)).toEqual(
+        expect(createPackageJSON(typing, "1.0", packages, Registry.Github)).toEqual(
             expect.stringContaining('"name": "@types/jquery"'));
     },
     async githubPackageJsonRegistry() {
         const packages = AllPackages.from(createTypesData(), await readNotNeededPackages(createMockDT()));
         const typing = new TypingsData(createRawPackage(License.MIT), /*isLatest*/ true);
-        const s = createPackageJSON(typing, "1.0", packages, Registry.GithubPackages);
+        const s = createPackageJSON(typing, "1.0", packages, Registry.Github);
         expect(s).toEqual(expect.stringContaining('publishConfig'));
         expect(s).toEqual(expect.stringContaining('"registry": "https://npm.pkg.github.com/"'));
     },
@@ -123,7 +123,7 @@ testo({
 }`);
     },
     async githubNotNeededPackageJson() {
-        const s = createNotNeededPackageJSON(createUnneededPackage(), Registry.GithubPackages);
+        const s = createNotNeededPackageJSON(createUnneededPackage(), Registry.Github);
         expect(s).toEqual(expect.stringContaining('@types'));
         expect(s).toEqual(expect.stringContaining('npm.pkg.github.com'));
     },

--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -55,8 +55,8 @@ async function generateTypingPackage(typing: TypingsData, packages: AllPackages,
     const typesDirectory = dt.subDir("types").subDir(typing.name);
     const packageFS = typing.isLatest ? typesDirectory : typesDirectory.subDir(`v${typing.major}`);
 
-    await writeCommonOutputs(typing, createPackageJSON(typing, version, packages, Registry.NPM), createReadme(typing, Registry.NPM), Registry.NPM);
-    await writeCommonOutputs(typing, createPackageJSON(typing, version, packages, Registry.Github), createReadme(typing, Registry.Github), Registry.Github);
+    await writeCommonOutputs(typing, createPackageJSON(typing, version, packages, Registry.NPM), createReadme(typing), Registry.NPM);
+    await writeCommonOutputs(typing, createPackageJSON(typing, version, packages, Registry.Github), createReadme(typing), Registry.Github);
     await Promise.all(
         typing.files.map(async file => writeFile(await outputFilePath(typing, Registry.NPM, file), packageFS.readFile(file))));
     await Promise.all(
@@ -97,7 +97,7 @@ interface Dependencies { [name: string]: string; }
 export function createPackageJSON(typing: TypingsData, version: string, packages: AllPackages, registry: Registry): string {
     // Use the ordering of fields from https://docs.npmjs.com/files/package.json
     const out: {} = {
-        name: registry === Registry.NPM ? typing.fullNpmName : typing.fullGithubName,
+        name: typing.fullNpmName,
         version,
         description: `TypeScript definitions for ${typing.libraryName}`,
         // keywords,
@@ -111,7 +111,7 @@ export function createPackageJSON(typing: TypingsData, version: string, packages
         repository: {
             type: "git",
             url: registry === Registry.Github
-                ? "https://github.com/TestTypePublishing/TypePublishing.git"
+                ? "https://github.com/types/_definitelytypedmirror.git"
                 : "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
             directory: `types/${typing.name}`,
         },
@@ -150,16 +150,16 @@ function dependencySemver(dependency: DependencyVersion): string {
     return dependency === "*" ? dependency : `^${dependency}`;
 }
 
-export function createNotNeededPackageJSON({ libraryName, license, name, fullNpmName, fullGithubName, sourceRepoURL, version }: NotNeededPackage, registry: Registry): string {
+export function createNotNeededPackageJSON({ libraryName, license, name, fullNpmName, sourceRepoURL, version }: NotNeededPackage, registry: Registry): string {
     const out = {
-        name: registry === Registry.NPM ? fullNpmName : fullGithubName,
+        name: fullNpmName,
         version: version.versionString,
         typings: null, // tslint:disable-line no-null-keyword
         description: `Stub TypeScript definitions entry for ${libraryName}, which provides its own types definitions`,
         main: "",
         scripts: {},
         author: "",
-        repository: registry === Registry.NPM ? sourceRepoURL : "https://github.com/TestTypePublishing/TypePublishing.git",
+        repository: registry === Registry.NPM ? sourceRepoURL : "https://github.com/types/_definitelytypedmirror.git",
         license,
         // No `typings`, that's provided by the dependency.
         dependencies: {
@@ -172,10 +172,10 @@ export function createNotNeededPackageJSON({ libraryName, license, name, fullNpm
     return JSON.stringify(out, undefined, 4);
 }
 
-export function createReadme(typing: TypingsData, reg: Registry): string {
+export function createReadme(typing: TypingsData): string {
     const lines: string[] = [];
     lines.push("# Installation");
-    lines.push(`> \`npm install --save ${reg === Registry.NPM ? typing.fullNpmName : typing.fullGithubName}\``);
+    lines.push(`> \`npm install --save ${typing.fullNpmName}\``);
     lines.push("");
 
     lines.push("# Summary");

--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -56,21 +56,21 @@ async function generateTypingPackage(typing: TypingsData, packages: AllPackages,
     const packageFS = typing.isLatest ? typesDirectory : typesDirectory.subDir(`v${typing.major}`);
 
     await writeCommonOutputs(typing, createPackageJSON(typing, version, packages, Registry.NPM), createReadme(typing), Registry.NPM);
-    await writeCommonOutputs(typing, createPackageJSON(typing, version, packages, Registry.GithubPackages), createReadme(typing), Registry.GithubPackages);
+    await writeCommonOutputs(typing, createPackageJSON(typing, version, packages, Registry.Github), createReadme(typing), Registry.Github);
     await Promise.all(
         typing.files.map(async file => writeFile(await outputFilePath(typing, Registry.NPM, file), packageFS.readFile(file))));
     await Promise.all(
-        typing.files.map(async file => writeFile(await outputFilePath(typing, Registry.GithubPackages, file), packageFS.readFile(file))));
+        typing.files.map(async file => writeFile(await outputFilePath(typing, Registry.Github, file), packageFS.readFile(file))));
 }
 
 async function generateNotNeededPackage(pkg: NotNeededPackage, client: CachedNpmInfoClient, log: Logger): Promise<void> {
     pkg = skipBadPublishes(pkg, client, log);
     await writeCommonOutputs(pkg, createNotNeededPackageJSON(pkg, Registry.NPM), pkg.readme(), Registry.NPM);
-    await writeCommonOutputs(pkg, createNotNeededPackageJSON(pkg, Registry.GithubPackages), pkg.readme(), Registry.GithubPackages);
+    await writeCommonOutputs(pkg, createNotNeededPackageJSON(pkg, Registry.Github), pkg.readme(), Registry.Github);
 }
 
 async function writeCommonOutputs(pkg: AnyPackage, packageJson: string, readme: string, registry: Registry): Promise<void> {
-    await mkdir(pkg.outputDirectory + (registry === Registry.GithubPackages ? "-github" : ""));
+    await mkdir(pkg.outputDirectory + (registry === Registry.Github ? "-github" : ""));
 
     await Promise.all([
         writeOutputFile("package.json", packageJson),
@@ -84,7 +84,7 @@ async function writeCommonOutputs(pkg: AnyPackage, packageJson: string, readme: 
 }
 
 async function outputFilePath(pkg: AnyPackage, registry: Registry, filename: string): Promise<string> {
-    const full = joinPaths(pkg.outputDirectory + (registry === Registry.GithubPackages ? "-github" : ""), filename);
+    const full = joinPaths(pkg.outputDirectory + (registry === Registry.Github ? "-github" : ""), filename);
     const dir = path.dirname(full);
     if (dir !== pkg.outputDirectory) {
         await mkdirp(dir);
@@ -110,7 +110,7 @@ export function createPackageJSON(typing: TypingsData, version: string, packages
         typesVersions:  makeTypesVersionsForPackageJson(typing.typesVersions),
         repository: {
             type: "git",
-            url: registry === Registry.GithubPackages
+            url: registry === Registry.Github
                 ? "https://github.com/types/_definitelytypedmirror.git"
                 : "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
             directory: `types/${typing.name}`,
@@ -120,7 +120,7 @@ export function createPackageJSON(typing: TypingsData, version: string, packages
         typesPublisherContentHash: typing.contentHash,
         typeScriptVersion: typing.minTypeScriptVersion,
     };
-    if (registry === Registry.GithubPackages) {
+    if (registry === Registry.Github) {
         (out as any).publishConfig = { registry: "https://npm.pkg.github.com/" };
     }
 
@@ -166,7 +166,7 @@ export function createNotNeededPackageJSON({ libraryName, license, name, fullNpm
             [name]: "*",
         },
     };
-    if (registry === Registry.GithubPackages) {
+    if (registry === Registry.Github) {
         (out as any).publishConfig = { registry: "https://npm.pkg.github.com/" };
     }
     return JSON.stringify(out, undefined, 4);

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -14,10 +14,8 @@ if (process.env.LONGJOHN) {
 export enum Registry {
     /** types-registry and @types/* on NPM */
     NPM,
-    /** @definitelytyped/types-registry on Github */
+    /** @definitelytyped/types-registry and @types/* on Github */
     Github,
-    /** @types/* on Github */
-    GithubPackages,
 }
 
 /** Settings that may be determined dynamically. */

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -12,8 +12,12 @@ if (process.env.LONGJOHN) {
 
 /** Which registry to publish to */
 export enum Registry {
+    /** types-registry and @types/* on NPM */
     NPM,
+    /** @definitelytyped/types-registry on Github */
     Github,
+    /** @types/* on Github */
+    GithubPackages,
 }
 
 /** Settings that may be determined dynamically. */

--- a/src/lib/npm-client.ts
+++ b/src/lib/npm-client.ts
@@ -7,7 +7,7 @@ import { resolve as resolveUrl } from "url";
 import { Fetcher, readFile, readJson, sleep, writeJson } from "../util/io";
 import { Logger, loggerWithErrors } from "../util/logging";
 import { createTgz } from "../util/tgz";
-import { identity, joinPaths, mapToRecord, recordToMap } from "../util/util";
+import { identity, joinPaths, mapToRecord, recordToMap, assertNever } from "../util/util";
 
 import { getSecret, Secret } from "./secrets";
 import { githubRegistry, npmApi, npmRegistry, npmRegistryHostName } from "./settings";
@@ -143,9 +143,9 @@ export class NpmPublishClient {
             case Registry.NPM:
                 return new this(new RegClient(config), { token: await getSecret(Secret.NPM_TOKEN) }, npmRegistry);
             case Registry.Github:
-                return new this(new RegClient(config), { token: await getSecret(Secret.GITHUB_REGISTRY_PUBLISH_ACCESS_TOKEN) }, githubRegistry);
-            case Registry.GithubPackages:
-                return new this(new RegClient(config), { token: await getSecret(Secret.GITHUB_PACKAGE_PUBLISH_ACCESS_TOKEN) }, githubRegistry);
+                return new this(new RegClient(config), { token: await getSecret(Secret.GITHUB_PUBLISH_ACCESS_TOKEN) }, githubRegistry);
+            default:
+                assertNever(registry);
         }
     }
 

--- a/src/lib/npm-client.ts
+++ b/src/lib/npm-client.ts
@@ -139,10 +139,13 @@ function splitToFixedSizeGroups(names: ReadonlyArray<string>, chunkSize: number)
 
 export class NpmPublishClient {
     static async create(config?: RegClient.Config, registry: Registry = Registry.NPM): Promise<NpmPublishClient> {
-        if (registry === Registry.Github) {
-            return new this(new RegClient(config), { token: await getSecret(Secret.GITHUB_PUBLISH_ACCESS_TOKEN) }, githubRegistry);
-        } else {
-            return new this(new RegClient(config), { token: await getSecret(Secret.NPM_TOKEN) }, npmRegistry);
+        switch (registry) {
+            case Registry.NPM:
+                return new this(new RegClient(config), { token: await getSecret(Secret.NPM_TOKEN) }, npmRegistry);
+            case Registry.Github:
+                return new this(new RegClient(config), { token: await getSecret(Secret.GITHUB_REGISTRY_PUBLISH_ACCESS_TOKEN) }, githubRegistry);
+            case Registry.GithubPackages:
+                return new this(new RegClient(config), { token: await getSecret(Secret.GITHUB_PACKAGE_PUBLISH_ACCESS_TOKEN) }, githubRegistry);
         }
     }
 

--- a/src/lib/package-publisher.ts
+++ b/src/lib/package-publisher.ts
@@ -33,7 +33,7 @@ export async function publishNotNeededPackage(client: NpmPublishClient, pkg: Not
 
 async function common(client: NpmPublishClient, pkg: AnyPackage, log: Logger, dry: boolean, registry: Registry): Promise<void> {
     const packageDir = pkg.outputDirectory;
-    const packageJson = await readFileAndWarn("generate", joinPaths(packageDir + (registry === Registry.GithubPackages ? "-github" : ""), "package.json"));
+    const packageJson = await readFileAndWarn("generate", joinPaths(packageDir + (registry === Registry.Github ? "-github" : ""), "package.json"));
     await client.publish(packageDir, packageJson, dry, log);
 }
 

--- a/src/lib/package-publisher.ts
+++ b/src/lib/package-publisher.ts
@@ -33,7 +33,7 @@ export async function publishNotNeededPackage(client: NpmPublishClient, pkg: Not
 
 async function common(client: NpmPublishClient, pkg: AnyPackage, log: Logger, dry: boolean, registry: Registry): Promise<void> {
     const packageDir = pkg.outputDirectory;
-    const packageJson = await readFileAndWarn("generate", joinPaths(packageDir + (registry === Registry.Github ? "-github" : ""), "package.json"));
+    const packageJson = await readFileAndWarn("generate", joinPaths(packageDir + (registry === Registry.GithubPackages ? "-github" : ""), "package.json"));
     await client.publish(packageDir, packageJson, dry, log);
 }
 

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -5,7 +5,7 @@ import { FS } from "../get-definitely-typed";
 import { assertSorted, joinPaths, mapValues, unmangleScopedPackage } from "../util/util";
 
 import { readDataFile } from "./common";
-import { outputDirPath, orgName, scopeName } from "./settings";
+import { outputDirPath, scopeName } from "./settings";
 import { Semver } from "./versions";
 
 export class AllPackages {
@@ -196,19 +196,9 @@ export abstract class PackageBase {
         return getFullNpmName(this.name);
     }
 
-    /** '@definitelytyped/foo' for a package 'foo'. */
-    get fullGithubName(): string {
-        return getFullGithubName(this.name);
-    }
-
     /** '@types%2ffoo' for a package 'foo'. */
     get fullEscapedNpmName(): string {
         return `@${scopeName}%2f${this.name}`;
-    }
-
-    /** '@definitelytyped%2ffoo' for a package 'foo'. */
-    get fullEscapedGithubName(): string {
-        return `@${orgName}%2f${this.name}`;
     }
 
     abstract readonly major: number;
@@ -220,10 +210,6 @@ export abstract class PackageBase {
     get outputDirectory(): string {
         return joinPaths(outputDirPath, this.desc);
     }
-}
-
-export function getFullGithubName(packageName: string): string {
-    return `@${orgName}/${getMangledNameForScopedPackage(packageName)}`;
 }
 
 export function getFullNpmName(packageName: string): string {

--- a/src/lib/secrets.ts
+++ b/src/lib/secrets.ts
@@ -33,10 +33,15 @@ export enum Secret {
      */
     NPM_TOKEN,
     /**
-     * Token used to publish packages to Github.
+     * Token used to publish types-registry to Github.
      * This *could* be the same as GITHUB_ACCESS_TOKEN, but I think it's better if they remain separate.
      */
-    GITHUB_PUBLISH_ACCESS_TOKEN,
+    GITHUB_REGISTRY_PUBLISH_ACCESS_TOKEN,
+    /**
+     * Token used to publish @types packages to Github.
+     * This *could* be the same as GITHUB_ACCESS_TOKEN, but I think it's better if they remain separate.
+     */
+    GITHUB_PACKAGE_PUBLISH_ACCESS_TOKEN,
 }
 
 export const allSecrets: Secret[] = mapDefined(Object.keys(Secret), key => {

--- a/src/lib/secrets.ts
+++ b/src/lib/secrets.ts
@@ -33,15 +33,10 @@ export enum Secret {
      */
     NPM_TOKEN,
     /**
-     * Token used to publish types-registry to Github.
+     * Token used to publish @definitelytyped/types-registry and @types/* to Github.
      * This *could* be the same as GITHUB_ACCESS_TOKEN, but I think it's better if they remain separate.
      */
-    GITHUB_REGISTRY_PUBLISH_ACCESS_TOKEN,
-    /**
-     * Token used to publish @types packages to Github.
-     * This *could* be the same as GITHUB_ACCESS_TOKEN, but I think it's better if they remain separate.
-     */
-    GITHUB_PACKAGE_PUBLISH_ACCESS_TOKEN,
+    GITHUB_PUBLISH_ACCESS_TOKEN,
 }
 
 export const allSecrets: Secret[] = mapDefined(Object.keys(Secret), key => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -9,8 +9,6 @@ export const githubRegistry = `https://${githubRegistryHostName}/`;
 export const npmApi = "api.npmjs.org";
 /** Note: this is 'types' and not '@types' */
 export const scopeName = "types";
-/** TODO: Change this to definitelytyped when it's ready */
-export const orgName = "testtypepublishing";
 const root = joinPaths(__dirname, "..", "..");
 export const dataDirPath = joinPaths(root, "data");
 export const outputDirPath = joinPaths(root, "output");

--- a/src/publish-packages.ts
+++ b/src/publish-packages.ts
@@ -23,13 +23,13 @@ if (!module.parent) {
             const log = logger()[0];
             try {
                 await deprecateNotNeededPackage(
-                    await NpmPublishClient.create(), AllPackages.readSingleNotNeeded(deprecateName, dt), /*dry*/ false, log, Registry.Github);
+                    await NpmPublishClient.create(undefined, Registry.Github), AllPackages.readSingleNotNeeded(deprecateName, dt), /*dry*/ false, log);
             } catch(e) {
                 // log and continue
                 log("publishing to github failed: " + e.toString());
             }
             await deprecateNotNeededPackage(
-                await NpmPublishClient.create(), AllPackages.readSingleNotNeeded(deprecateName, dt), /*dry*/ false, log, Registry.NPM);
+                await NpmPublishClient.create(undefined, Registry.NPM), AllPackages.readSingleNotNeeded(deprecateName, dt), /*dry*/ false, log);
         } else {
             await publishPackages(await readChangedPackages(await AllPackages.read(dt)), dry, process.env.GH_API_TOKEN || "", new Fetcher());
         }

--- a/src/publish-packages.ts
+++ b/src/publish-packages.ts
@@ -23,7 +23,7 @@ if (!module.parent) {
             const log = logger()[0];
             try {
                 await deprecateNotNeededPackage(
-                    await NpmPublishClient.create(undefined, Registry.Github), AllPackages.readSingleNotNeeded(deprecateName, dt), /*dry*/ false, log);
+                    await NpmPublishClient.create(undefined, Registry.GithubPackages), AllPackages.readSingleNotNeeded(deprecateName, dt), /*dry*/ false, log);
             } catch(e) {
                 // log and continue
                 log("publishing to github failed: " + e.toString());
@@ -50,13 +50,13 @@ export default async function publishPackages(
     }
 
     const client = await NpmPublishClient.create(undefined, Registry.NPM);
-    const ghClient = await NpmPublishClient.create(undefined, Registry.Github);
+    const ghClient = await NpmPublishClient.create(undefined, Registry.GithubPackages);
 
     for (const cp of changedPackages.changedTypings) {
         log(`Publishing ${cp.pkg.desc}...`);
 
         try {
-            await publishTypingsPackage(ghClient, cp, dry, log, Registry.Github);
+            await publishTypingsPackage(ghClient, cp, dry, log, Registry.GithubPackages);
         } catch(e) {
             // log and continue
             log("publishing to github failed: " + e.toString());
@@ -138,7 +138,7 @@ export default async function publishPackages(
         for (const n of changedPackages.changedNotNeededPackages) {
             const target = skipBadPublishes(n, infoClient, log)
             try {
-                await publishNotNeededPackage(ghClient, target, dry, log, Registry.Github);
+                await publishNotNeededPackage(ghClient, target, dry, log, Registry.GithubPackages);
             } catch(e) {
                 // log and continue
                 log("publishing to github failed: " + e.toString());

--- a/src/publish-packages.ts
+++ b/src/publish-packages.ts
@@ -23,7 +23,7 @@ if (!module.parent) {
             const log = logger()[0];
             try {
                 await deprecateNotNeededPackage(
-                    await NpmPublishClient.create(undefined, Registry.GithubPackages), AllPackages.readSingleNotNeeded(deprecateName, dt), /*dry*/ false, log);
+                    await NpmPublishClient.create(undefined, Registry.Github), AllPackages.readSingleNotNeeded(deprecateName, dt), /*dry*/ false, log);
             } catch(e) {
                 // log and continue
                 log("publishing to github failed: " + e.toString());
@@ -50,13 +50,13 @@ export default async function publishPackages(
     }
 
     const client = await NpmPublishClient.create(undefined, Registry.NPM);
-    const ghClient = await NpmPublishClient.create(undefined, Registry.GithubPackages);
+    const ghClient = await NpmPublishClient.create(undefined, Registry.Github);
 
     for (const cp of changedPackages.changedTypings) {
         log(`Publishing ${cp.pkg.desc}...`);
 
         try {
-            await publishTypingsPackage(ghClient, cp, dry, log, Registry.GithubPackages);
+            await publishTypingsPackage(ghClient, cp, dry, log, Registry.Github);
         } catch(e) {
             // log and continue
             log("publishing to github failed: " + e.toString());
@@ -138,7 +138,7 @@ export default async function publishPackages(
         for (const n of changedPackages.changedNotNeededPackages) {
             const target = skipBadPublishes(n, infoClient, log)
             try {
-                await publishNotNeededPackage(ghClient, target, dry, log, Registry.GithubPackages);
+                await publishNotNeededPackage(ghClient, target, dry, log, Registry.Github);
             } catch(e) {
                 // log and continue
                 log("publishing to github failed: " + e.toString());

--- a/src/publish-registry.ts
+++ b/src/publish-registry.ts
@@ -62,7 +62,7 @@ export default async function publishRegistry(dt: FS, allPackages: AllPackages, 
             // This may have just been due to a timeout, so test if types-registry@next is a subset of the one we're about to publish.
             // If so, we should just update it to "latest" now.
             log("Old version of types-registry was never tagged latest, so updating");
-            await validateIsSubset(await readNotNeededPackages(dt), log);
+            await validateIsSubset(readNotNeededPackages(dt), log);
             await (await publishClient()).tag(packageName, highestSemverVersion.versionString, "latest", dry, log);
         } else if (npmContentHash !== newContentHash && isTimeForNewVersion) {
             log("New packages have been added, so publishing a new registry.");


### PR DESCRIPTION
1. Switch from @testtypepublishing to @types. This simplifies some NPM-vs-Github code because the package name is the same.
2. On Github. split @definitelytyped/types-registry publication from @types/* publication. They are two separate publishes to two orgs that need two tokens.

TODO: This PR requires a new token for @types registration and changes the name for the @definitelytyped token. These two are *different* from the token used to access the Github API for posting comments to PRs.