### PR TITLE
[AppInsights] Check if key env exists before enabling

### DIFF
--- a/src/full.ts
+++ b/src/full.ts
@@ -18,8 +18,10 @@ import { assertDefined, currentTimeStamp, logUncaughtErrors, numberOfOsProcesses
 import validate from "./validate";
 
 if (!module.parent) {
-    appInsights.setup();
-    appInsights.start();
+    if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
+        appInsights.setup();
+        appInsights.start();
+    }
     const dry = !!yargs.argv.dry;
     logUncaughtErrors(full(dry, currentTimeStamp(), process.env.GH_API_TOKEN || "", new Fetcher(), Options.defaults, loggerWithErrors()[0]));
 }

--- a/src/get-definitely-typed.ts
+++ b/src/get-definitely-typed.ts
@@ -33,8 +33,10 @@ export interface FS {
 }
 
 if (!module.parent) {
-    appInsights.setup();
-    appInsights.start();
+    if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
+        appInsights.setup();
+        appInsights.start();
+    }
     const dry = !!yargs.argv.dry;
     console.log("gettingDefinitelyTyped: " + (dry ? "from github" : "locally"));
     logUncaughtErrors(async () => {

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -21,8 +21,10 @@ export default async function main(): Promise<void> {
         console.log("The environment variables GITHUB_SECRET and GITHUB_ACCESS_TOKEN and PORT must be set.");
     } else {
         console.log(`=== ${dry ? "DRY" : "PRODUCTION"} RUN ===`);
-        appInsights.setup(process.env.APPINSIGHTS_INSTRUMENTATIONKEY).start();
-        console.log("Done initialising App Insights");
+        if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
+            appInsights.setup().start();
+            console.log("Done initialising App Insights");
+        }
         const fetcher = new Fetcher();
         try {
             const s = await webhookServer(key, githubAccessToken, dry, fetcher, Options.azure);


### PR DESCRIPTION
[This library](https://www.npmjs.com/package/applicationinsights) and its configuration isn’t mentioned in the README and it doesn’t seem like something that we necessarily need to run while locally developing and testing this tool.

I made it conditionally enabled if the default env key the library looks for exists.

cc @orta 