### PR TITLE
fix: Format contributors links properly

### DIFF
--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -207,7 +207,7 @@ export function createReadme(typing: TypingsData): string {
     lines.push("");
 
     lines.push("# Credits");
-    const contributors = typing.contributors.map(({ name, url }) => `${name} (${url})`).join(", ").replace(/, ([^,]+)$/, ", and $1");
+    const contributors = typing.contributors.map(({ name, url }) => `[${name}](${url})`).join(", ").replace(/, ([^,]+)$/, ", and $1");
     lines.push(`These definitions were written by ${contributors}.`);
     lines.push("");
 


### PR DESCRIPTION
In #698 links in README on NPM were clickable, but [now](https://www.npmjs.com/package/@types/gapi.client.sheets#credits) they are just plain text.

This PR aims to do this after markdown transformation: 
```html
<a href="https://github.com/me">My Self</a>
```

**Before:**
![Screenshot from 2020-01-08 17-43-46](https://user-images.githubusercontent.com/7756211/71993059-1da67c80-323f-11ea-85c2-d7788416b22f.png)
```markdown
These definitions were written by Maxim Mazurok (https://github.com/Maxim-Mazurok).
```

**After:**
![Screenshot from 2020-01-08 17-44-21](https://user-images.githubusercontent.com/7756211/71993066-20a16d00-323f-11ea-97c7-008c8693286a.png)
```markdown
These definitions were written by [Maxim Mazurok](https://github.com/Maxim-Mazurok).
```

So that no matter how npmjs treats plain-text links, now link will always be clickable, also consuming less space and being more readable.