### PR TITLE
chore(whitelist): add some hapi packages

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -8,6 +8,9 @@
 @electron/get
 @emotion/core
 @emotion/styled
+@hapi/boom
+@hapi/iron
+@hapi/wreck
 @jest/environment
 @jest/fake-timers
 @jest/transform


### PR DESCRIPTION
Hapi is rather slowly moving to publishing it's own types, however the core `@hapi/hapi` and some of it's friends have not been moved yet while some of their dependencies have.
I need to be able to reference these packages in order to publish hapi v19 typings to DT.