### PR TITLE
Add @emotion/serialize to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -7,6 +7,7 @@
 @babel/types
 @electron/get
 @emotion/core
+@emotion/serialize
 @emotion/styled
 @hapi/boom
 @hapi/iron


### PR DESCRIPTION
Required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41567

Proof: https://github.com/emotion-js/emotion/tree/master/packages/serialize/types