### PR TITLE
deprecated packages use unescapedName for dependency in package.json

### DIFF
--- a/src/generate-packages.test.ts
+++ b/src/generate-packages.test.ts
@@ -122,6 +122,29 @@ testo({
     }
 }`);
     },
+    scopedNotNeededPackageJson() {
+        const scopedUnneeded = new NotNeededPackage({
+        libraryName: "@google-cloud/pubsub",
+        typingsPackageName: "google-cloud__pubsub",
+        asOfVersion: "0.26.0",
+        sourceRepoURL: "https://github.com/googleapis/nodejs-storage",
+    });
+        const s = createNotNeededPackageJSON(scopedUnneeded, Registry.NPM);
+        expect(s).toEqual(`{
+    "name": "@types/google-cloud__pubsub",
+    "version": "0.26.0",
+    "typings": null,
+    "description": "Stub TypeScript definitions entry for @google-cloud/pubsub, which provides its own types definitions",
+    "main": "",
+    "scripts": {},
+    "author": "",
+    "repository": "https://github.com/googleapis/nodejs-storage",
+    "license": "MIT",
+    "dependencies": {
+        "@google-cloud/pubsub": "*"
+    }
+}`);
+    },
     githubNotNeededPackageJson() {
         const s = createNotNeededPackageJSON(createUnneededPackage(), Registry.Github);
         expect(s).toEqual(expect.stringContaining("@types"));

--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -153,7 +153,7 @@ export function createNotNeededPackageJSON(
     {
         libraryName,
         license,
-        name,
+        unescapedName,
         fullNpmName,
         sourceRepoURL,
         version,
@@ -172,7 +172,7 @@ export function createNotNeededPackageJSON(
         license,
         // No `typings`, that's provided by the dependency.
         dependencies: {
-            [name]: "*",
+            [unescapedName]: "*",
         },
     };
     if (registry === Registry.Github) {


### PR DESCRIPTION
previously it was `name` which is incorrect for scoped packages, because it's the DT-mangled version -- scope__name -- not the npm name: @scope/name.

This means the 38 scoped-package deprecations currently on npm are unusable. I'm not sure it's worth fixing, though, because the workaround is to remove the useless package from from your dependencies.