### PR TITLE
Assert that dependencies exist on npm

### DIFF
--- a/src/calculate-versions.ts
+++ b/src/calculate-versions.ts
@@ -50,7 +50,9 @@ async function computeChangedPackages(
         if (needsPublish) {
             log.info(`Changed: ${pkg.desc}`);
             for (const { name } of pkg.packageJsonDependencies) {
-                assertDefined(await client.fetchAndCacheNpmInfo(name), `'${pkg.name}' depends on '${name}' which does not exist on npm. All dependencies must exist.`);
+                assertDefined(
+                    await client.fetchAndCacheNpmInfo(name),
+                    `'${pkg.name}' depends on '${name}' which does not exist on npm. All dependencies must exist.`);
             }
             const latestVersion = pkg.isLatest ?
                 undefined :
@@ -62,7 +64,9 @@ async function computeChangedPackages(
     log.info("# Computing deprecated packages...");
     const changedNotNeededPackages = await mapDefinedAsync(allPackages.allNotNeeded(), async pkg => {
         if (!await isAlreadyDeprecated(pkg, client, log)) {
-            assertDefined(await client.fetchAndCacheNpmInfo(pkg.unescapedName), `To deprecate '@types/${pkg.name}', '${pkg.unescapedName}' must exist on npm.`);
+            assertDefined(
+                await client.fetchAndCacheNpmInfo(pkg.unescapedName),
+                `To deprecate '@types/${pkg.name}', '${pkg.unescapedName}' must exist on npm.`);
             log.info(`To be deprecated: ${pkg.name}`);
             return pkg;
         }

--- a/src/calculate-versions.ts
+++ b/src/calculate-versions.ts
@@ -49,6 +49,9 @@ async function computeChangedPackages(
         const { version, needsPublish } = await fetchTypesPackageVersionInfo(pkg, client, /*publish*/ true, log);
         if (needsPublish) {
             log.info(`Changed: ${pkg.desc}`);
+            for (const { name } of pkg.packageJsonDependencies) {
+                assertDefined(await client.fetchAndCacheNpmInfo(name), `'${pkg.name}' depends on '${name}' which does not exist on npm. All dependencies must exist.`);
+            }
             const latestVersion = pkg.isLatest ?
                 undefined :
                 (await fetchTypesPackageVersionInfo(allPackages.getLatest(pkg), client, /*publish*/ true)).version;
@@ -59,6 +62,7 @@ async function computeChangedPackages(
     log.info("# Computing deprecated packages...");
     const changedNotNeededPackages = await mapDefinedAsync(allPackages.allNotNeeded(), async pkg => {
         if (!await isAlreadyDeprecated(pkg, client, log)) {
+            assertDefined(await client.fetchAndCacheNpmInfo(pkg.unescapedName), `To deprecate '@types/${pkg.name}', '${pkg.unescapedName}' must exist on npm.`);
             log.info(`To be deprecated: ${pkg.name}`);
             return pkg;
         }


### PR DESCRIPTION
During publishing, assert that dependencies exist on npm; for normal packages this needs to be true for dependencies from `package.json`, and for deprecated packages, this needs to be true for the replacement package, which types-publisher adds as a dependency of the deprecated package.

I tested this manually since calculate-versions is not already tested, and it largely deals with fetching NPM info, so it would be time-consuming to add tests.

Note that this change does NOT check the contents of the package, just that it exists. For example, I found that when I test-deprecated a random scoped package `@carbon/colors`, somebody already had created a name-mangled `carbon__colors`. So, for that hypothetical case, this assert would not have caught #731's bug.