### PR TITLE
feat(connect-mongo): add connect-mongo to white list

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -64,6 +64,7 @@ cassandra-driver
 chalk
 chokidar
 commander
+connect-mongo
 cordova-plugin-camera
 cordova-plugin-file
 cordova-plugin-file-transfer


### PR DESCRIPTION
As of version 3.1.1 the connect-mongo ships its own definition file.
Adding to white list will enable using 'connect-mongo' as external
dependency in the existing definitions like passport.socketio.

DefinitelyTyped/DefinitelyTyped#42047

Thanks!