### PR TITLE
fix: add @types/mkdirp-promise to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -27,6 +27,7 @@
 @types/firebase
 @types/highcharts
 @types/hoist-non-react-statics
+@types/mkdirp-promise
 @types/next-redux-wrapper
 @types/ink
 @types/js-data


### PR DESCRIPTION
_disclaimer: I have no idea what I'm doing_

Greeting folks!  
Recently, the npm module [`mkdirp`](https://github.com/isaacs/node-mkdirp/blob/master/CHANGELOG.md#10) when through a rewrite.  The interface was changed from being callback based to promise based.  

DefinitelyTyped includes an [`@types/mkdirp`](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mkdirp) package, which is currently out of date as compared to the new shiny 1.0 of `mkdirp`.  It snaps to the `0.5.1` version of the module.  

I would like to update the types to support 1.0!  So I submitted this shiny PR:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42108

The change to `@types/mkdirp` worked great, but ... tests for [`@types/mkdirp-promise`](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mkdirp-promise) started to [fail](http://wompwompwomp.com/).   It turns out the promise variant of the module was depending on the local callback based types.  

I tried to figure out from the README how to handle this, and ended up trying to add a `package.json` to my [PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42108) so I could specify the supported versions of `@types/mkdirp` to use along with `@types/mkdirp-promise`.  The directions from the README of DefinitelyTyped led me here, to submit this PR. 

I can't help but feel like I'm doing something wrong, since I get the gist that this whitelist is about modules that used to have DefinitelyTyped packages, and then started doing their own distributions.  I am just a simple human trying to use `mkdirp@1.0.0` :)

Any help, feedback, or guidance y'all could provide would be greatly appreciated!