### PR TITLE
Don't double-prefix version directory name

### DIFF
--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -524,7 +524,7 @@ export class TypingsData extends PackageBase {
 
     /** Path to this package, *relative* to the DefinitelyTyped directory. */
     get subDirectoryPath(): string {
-        return this.isLatest ? this.name : `${this.name}/v${this.versionDirectoryName}`;
+        return this.isLatest ? this.name : `${this.name}/${this.versionDirectoryName}`;
     }
 }
 


### PR DESCRIPTION
Since [this change](https://github.com/microsoft/types-publisher/commit/24c6039a0313998e7290c7fae09eef36ea61910d#diff-1636a6a99ec38efcbb3aff7b3643801dR527), `pkg.subDirectoryPath` returns paths like [`node/vv10`](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=35065&view=logs&j=8635df7d-ecde-52a7-c7a8-84b998e35690&t=c264d665-0b79-59b7-7e04-9965cbe74860&l=7118).