### PR TITLE
Don't double-prefix version directory name

### DIFF
--- a/src/lib/packages.test.ts
+++ b/src/lib/packages.test.ts
@@ -35,4 +35,9 @@ describe(TypingsVersions, () => {
         expect(versions.get({ major: 2, minor: 0 }).major).toEqual(2);
         expect(versions.get({ major: 2, minor: 0 }).minor).toEqual(0);
     });
+
+    it("formats a version directory names", () => {
+        expect(versions.get({ major: 2, minor: 0 }).versionDirectoryName).toEqual("v2");
+        expect(versions.get({ major: 2, minor: 0 }).subDirectoryPath).toEqual("jquery/v2");
+    });
 });

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -524,7 +524,7 @@ export class TypingsData extends PackageBase {
 
     /** Path to this package, *relative* to the DefinitelyTyped directory. */
     get subDirectoryPath(): string {
-        return this.isLatest ? this.name : `${this.name}/v${this.versionDirectoryName}`;
+        return this.isLatest ? this.name : `${this.name}/${this.versionDirectoryName}`;
     }
 }
 


### PR DESCRIPTION
Supersedes #739 (or merge once #739 has been merged).

@sandersn I tried testing if this issue was causing CI failures like [these](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped/builds/651445339#L500), but I was unable to reproduce it with e.g.:

```bash
node bin/tester/test-runner.js react-native-autocomplete-input
```