### PR TITLE
Use dtslint@latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "azure-storage": "^2.0.0",
     "charm": "^1.0.2",
     "definitelytyped-header-parser": "3.8.2",
-    "dtslint": "^2.0.5",
+    "dtslint": "latest",
     "fs-extra": "4.0.0",
     "fstream": "^1.0.12",
     "longjohn": "^0.2.11",


### PR DESCRIPTION
This was effectively always the case because by default types-publisher
uses the dtslint installed in DefinitelyTyped, which is dtslint@latest.