### PR TITLE
correctly format TypingVersion in package.json

### DIFF
--- a/src/generate-packages.test.ts
+++ b/src/generate-packages.test.ts
@@ -8,7 +8,7 @@ function createRawPackage(license: License): TypingsDataRaw {
     return {
         libraryName: "jquery",
         typingsPackageName: "jquery",
-        dependencies: [],
+        dependencies: [{ name: "madeira", version: { major: 1 } }],
         testDependencies: [],
         pathMappings: [],
         contributors: [{ name: "A", url: "b@c.d", githubUsername: "e" }],
@@ -18,11 +18,11 @@ function createRawPackage(license: License): TypingsDataRaw {
         typesVersions: [],
         files: ["index.d.ts", "jquery.test.ts"],
         license,
-        packageJsonDependencies: [],
+        packageJsonDependencies: [{ name: "balzac", version: "~3" }],
         contentHash: "11",
         projectName: "jquery.org",
         globals: [],
-        declaredModules: ["juqery"],
+        declaredModules: ["jquery"],
     };
 }
 function createTypesData(): TypesDataFile {
@@ -30,6 +30,9 @@ function createTypesData(): TypesDataFile {
         jquery: {
             1: createRawPackage(License.MIT),
         },
+        madeira: {
+            1: createRawPackage(License.Apache20),
+        }
     };
 }
 function createUnneededPackage() {
@@ -57,9 +60,9 @@ testo({
         const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
         expect(createReadme(typing)).toEqual(expect.stringContaining("jquery.org"));
     },
-    readmeNoDependencies() {
+    readmeOneDependency() {
         const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
-        expect(createReadme(typing)).toEqual(expect.stringContaining("Dependencies: none"));
+        expect(createReadme(typing)).toEqual(expect.stringContaining("Dependencies: [@types/madeira](https://npmjs.com/package/@types/madeira)"));
     },
     readmeNoGlobals() {
         const typing = new TypingsData(createRawPackage(License.Apache20), /*isLatest*/ true);
@@ -88,7 +91,10 @@ testo({
         "directory": "types/jquery"
     },
     "scripts": {},
-    "dependencies": {},
+    "dependencies": {
+        "@types/madeira": "^1",
+        "balzac": "~3"
+    },
     "typesPublisherContentHash": "11",
     "typeScriptVersion": "3.0"
 }`);

--- a/src/generate-packages.test.ts
+++ b/src/generate-packages.test.ts
@@ -32,7 +32,7 @@ function createTypesData(): TypesDataFile {
         },
         madeira: {
             1: createRawPackage(License.Apache20),
-        }
+        },
     };
 }
 function createUnneededPackage() {

--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -7,7 +7,7 @@ import { FS, getDefinitelyTyped } from "./get-definitely-typed";
 import { Options, Registry } from "./lib/common";
 import { CachedNpmInfoClient, UncachedNpmInfoClient, withNpmCache } from "./lib/npm-client";
 import {
-    AllPackages, AnyPackage, DependencyVersion, getFullNpmName, License, NotNeededPackage, PackageJsonDependency, TypingsData, formatTypingVersion,
+    AllPackages, AnyPackage, DependencyVersion, formatTypingVersion, getFullNpmName, License, NotNeededPackage, PackageJsonDependency, TypingsData,
 } from "./lib/packages";
 import { outputDirPath, sourceBranch } from "./lib/settings";
 import { ChangedPackages, readChangedPackages, skipBadPublishes } from "./lib/versions";

--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -7,7 +7,7 @@ import { FS, getDefinitelyTyped } from "./get-definitely-typed";
 import { Options, Registry } from "./lib/common";
 import { CachedNpmInfoClient, UncachedNpmInfoClient, withNpmCache } from "./lib/npm-client";
 import {
-    AllPackages, AnyPackage, DependencyVersion, getFullNpmName, License, NotNeededPackage, PackageJsonDependency, TypingsData,
+    AllPackages, AnyPackage, DependencyVersion, getFullNpmName, License, NotNeededPackage, PackageJsonDependency, TypingsData, formatTypingVersion,
 } from "./lib/packages";
 import { outputDirPath, sourceBranch } from "./lib/settings";
 import { ChangedPackages, readChangedPackages, skipBadPublishes } from "./lib/versions";
@@ -146,8 +146,7 @@ function getDependencies(packageJsonDependencies: ReadonlyArray<PackageJsonDepen
 }
 
 function dependencySemver(dependency: DependencyVersion): string {
-    // tslint:disable-next-line strict-string-expressions
-    return dependency === "*" ? dependency : `^${dependency}`;
+    return dependency === "*" ? dependency : "^" + formatTypingVersion(dependency);
 }
 
 export function createNotNeededPackageJSON(


### PR DESCRIPTION
Fixes #746 

Note that I didn't yet look for other incorrect stringifications of TypingVersion. I did look for other exceptions to the tslint rule and the others were in errors, which I don't care about as much. They're still probably wrong though.