### PR TITLE
Add `jimp` to the deps whitelist.

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -112,6 +112,7 @@ jest-environment-node
 jest-environment-jsdom
 jest-mock
 jest-snapshot
+jimp
 jointjs
 levelup
 lit-element


### PR DESCRIPTION
The `jimp` ships with its own type definitions. The definition files for
the consumers of that package need to install this via dependency list in
package.json.

https://github.com/oliver-moran/jimp

Thanks!