### PR TITLE
Loosen check on name of ts\d.\d subdirectory

### DIFF
--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -94,6 +94,7 @@ interface LsMinusTypesVersionsAndPackageJson {
     readonly typesVersions: ReadonlyArray<TypeScriptVersion>;
     readonly hasPackageJson: boolean;
 }
+
 function getTypesVersionsAndPackageJson(ls: ReadonlyArray<string>): LsMinusTypesVersionsAndPackageJson {
     const withoutPackageJson = ls.filter(name => name !== packageJsonName);
     const [remainingLs, typesVersions] = split(withoutPackageJson, fileOrDirectoryName => {
@@ -101,10 +102,10 @@ function getTypesVersionsAndPackageJson(ls: ReadonlyArray<string>): LsMinusTypes
         if (match === null) { return undefined; }
 
         const version = match[1];
-        if (!isTypeScriptVersion(version)) {
-            throw new Error(`Directory name starting with 'ts' should be a valid TypeScript version. Got: ${version}`);
+        if (parseInt(version) < 3) {
+            throw new Error(`Directory name starting with 'ts' should be a TypeScript version newer than 3.0. Got: ${version}`);
         }
-        return version;
+        return version as TypeScriptVersion;
     });
     return { remainingLs, typesVersions, hasPackageJson: withoutPackageJson.length !== ls.length };
 }

--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -1,4 +1,4 @@
-import { isTypeScriptVersion, parseHeaderOrFail, TypeScriptVersion } from "definitelytyped-header-parser";
+import { parseHeaderOrFail, TypeScriptVersion } from "definitelytyped-header-parser";
 import * as ts from "typescript";
 
 import { FS } from "../get-definitely-typed";
@@ -102,7 +102,7 @@ function getTypesVersionsAndPackageJson(ls: ReadonlyArray<string>): LsMinusTypes
         if (match === null) { return undefined; }
 
         const version = match[1];
-        if (parseInt(version) < 3) {
+        if (parseInt(version, 10) < 3) {
             throw new Error(`Directory name starting with 'ts' should be a TypeScript version newer than 3.0. Got: ${version}`);
         }
         return version as TypeScriptVersion;


### PR DESCRIPTION
Just require that it's 3.0 or above. This is quick fix to allow publishing ts\d.\d directories for typescript@next so that DT can be fixed up immediately after merging new features into Typescript master.

The correct solution would be to change definitelytyped-header-parser to include typescript@next in the TypeScriptVersion type, then add a new type guard function named `isTypeScriptNext`.

Howevever, I need to check whether adding typescript@next to the TypeScriptVersion type would break anything. I don't think so, so I'll probably make that change when I update definitelytyped-header-parser for 3.9.