### PR TITLE
Whitelist `typescript-tuple` library

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -185,6 +185,7 @@ tslint
 ts-toolbelt
 tweetnacl
 typescript
+typescript-tuple
 utility-types
 vega-typings
 vfile


### PR DESCRIPTION
This library along with `ts-toolbelt` (which is already in the list) provides very convenient helpers to operate on tuple types.
This is very common for typings to operate on tuple types, and for authors, it is easier to use well-designed solutions.
This particular library works with tuples a little better than `ts-toolbelt` and provides more helper types.

npm: [`typescript-tuple`](https://www.npmjs.com/package/typescript-tuple)