### PR TITLE
whitelist acorn

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -45,6 +45,7 @@
 abort-controller
 actions-on-google
 activex-helpers
+acorn
 adal-node
 ajv
 anydb-sql


### PR DESCRIPTION
acorn distributes its own types since v6.0.0.

See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43670