### PR TITLE
nodeBuiltins depend on @types/node

### DIFF
--- a/src/lib/definition-parser.ts
+++ b/src/lib/definition-parser.ts
@@ -397,10 +397,9 @@ function calculateDependencies(
 }
 
 const nodeBuiltins: ReadonlySet<string> = new Set([
-    "assert", "async_hooks", "buffer", "child_process", "cluster", "console", "constants", "crypto",
-    "dgram", "dns", "domain", "events", "fs", "http", "http2", "https", "module", "net", "os",
-    "path", "perf_hooks", "process", "punycode", "querystring", "readline", "repl", "stream",
-    "string_decoder", "timers", "tls", "tty", "url", "util", "v8", "vm", "zlib",
+    "assert",
+    "events",
+    "punycode",
 ]);
 
 function parseDependencyVersionFromPath(packageName: string, dependencyName: string, dependencyPath: string): TypingVersion {


### PR DESCRIPTION
Like non-built-in modules, add a dependency (on `@types/node` in this case) given the following (unless there's already a dependency, on `@types/node` or on the specified module):
```TypeScript
import * as http from "http";
```
Otherwise it errors:
```
error TS2307: Cannot find module 'http' or its corresponding type declarations.
```