### PR TITLE
Add glaze and treat to dependenciesWhitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -184,6 +184,7 @@ sw-toolbox
 swagger-parser
 terser
 three
+treat
 tslint
 ts-toolbelt
 tweetnacl

--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -95,6 +95,7 @@ fastify
 final-form
 flatpickr
 form-data
+glaze
 google-auth-library
 google-gax
 got


### PR DESCRIPTION
Required for seamless augmentation of React attributes, in order to add the `sx` prop for any element: https://github.com/kripod/glaze/pull/16#issuecomment-616528041