### PR TITLE
Whitelist `@jest/jest-diff` and `@jest/pretty-format`

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -14,6 +14,8 @@
 @hapi/wreck
 @jest/environment
 @jest/fake-timers
+@jest/jest-diff
+@jest/pretty-format
 @jest/transform
 @jest/types
 @loadable/component


### PR DESCRIPTION
I think these changes are necessary to support https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44033.

The DefinitelyTyped [jest-environment-puppeteer](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jest-environment-puppeteer/index.d.ts) package has transitive dependencies on `@jest` and the DefinitelyTyped CI is [failing](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44033#issuecomment-616241339) because it can't resolve the external dependencies to `@jest/jest-diff` ([source](https://github.com/facebook/jest/tree/master/packages/jest-diff)) and `@jest/pretty-format` ([source](https://github.com/facebook/jest/tree/master/packages/pretty-format)).

Thanks!