### PR TITLE
Add `@types/chai` to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -23,6 +23,7 @@
 @storybook/addons
 @storybook/react
 @types/base-x
+@types/chai
 @types/expect
 @types/firebase
 @types/highcharts


### PR DESCRIPTION
Needed for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44113

> `@types/sinon-chai` now requires versions of `@types/chai` 4.2.0 and above, because it references `ChaiPlugin`, and `ChaiPlugin` was added in `@types/chai` 4.2.0: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37451#issuecomment-519584606