### PR TITLE
Deduplicate dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,9 @@ This file is a key/value mapping used by other steps in the process.
                 "misc.d.ts"
             ],
             "license": "MIT",
-            "dependencies": [
-                {
-                    "name": "sizzle",
-                    "version": "*"
-                }
-            ],
+            "dependencies": {
+                "sizzle": "*"
+            },
             "testDependencies": [],
             "pathMappings": [],
             "packageJsonDependencies": [],

--- a/src/check-parse-results.ts
+++ b/src/check-parse-results.ts
@@ -24,8 +24,8 @@ export default async function checkParseResults(includeNpmChecks: boolean, dt: F
     const packages = allPackages.allPackages();
     for (const pkg of packages) {
         if (pkg instanceof TypingsData) {
-            for (const dep of pkg.dependencies) {
-                dependedOn.add(dep.name);
+            for (const dep of Object.keys(pkg.dependencies)) {
+                dependedOn.add(dep);
             }
             for (const dep of pkg.testDependencies) {
                 dependedOn.add(dep);

--- a/src/generate-packages.test.ts
+++ b/src/generate-packages.test.ts
@@ -8,7 +8,7 @@ function createRawPackage(license: License): TypingsDataRaw {
     return {
         libraryName: "jquery",
         typingsPackageName: "jquery",
-        dependencies: [{ name: "madeira", version: { major: 1 } }],
+        dependencies: { madeira: { major: 1 } },
         testDependencies: [],
         pathMappings: [],
         contributors: [{ name: "A", url: "b@c.d", githubUsername: "e" }],

--- a/src/generate-packages.ts
+++ b/src/generate-packages.ts
@@ -135,11 +135,11 @@ function getDependencies(packageJsonDependencies: ReadonlyArray<PackageJsonDepen
         dependencies[name] = version;
     }
 
-    for (const dependency of typing.dependencies) {
-        const typesDependency = getFullNpmName(dependency.name);
+    for (const [name, version] of Object.entries(typing.dependencies)) {
+        const typesDependency = getFullNpmName(name);
         // A dependency "foo" is already handled if we already have a dependency on the package "foo" or "@types/foo".
-        if (!packageJsonDependencies.some(d => d.name === dependency.name || d.name === typesDependency) && allPackages.hasTypingFor(dependency)) {
-            dependencies[typesDependency] = dependencySemver(dependency.version);
+        if (!packageJsonDependencies.some(d => d.name === name || d.name === typesDependency) && allPackages.hasTypingFor({ name, version })) {
+            dependencies[typesDependency] = dependencySemver(version);
         }
     }
     return sortObjectKeys(dependencies);
@@ -201,7 +201,7 @@ export function createReadme(typing: TypingsData): string {
     lines.push("");
     lines.push("### Additional Details");
     lines.push(` * Last updated: ${(new Date()).toUTCString()}`);
-    const dependencies = Array.from(typing.dependencies).map(d => getFullNpmName(d.name));
+    const dependencies = Object.keys(typing.dependencies).map(getFullNpmName);
     lines.push(` * Dependencies: ${dependencies.length ? dependencies.map(d => `[${d}](https://npmjs.com/package/${d})`).join(", ") : "none"}`);
     lines.push(` * Global values: ${typing.globals.length ? typing.globals.map(g => `\`${g}\``).join(", ") : "none"}`);
     lines.push("");

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -114,7 +114,7 @@ export class AllPackages {
 
     /** Returns all of the dependences *that have typings*, ignoring others, and including test dependencies. */
     *allDependencyTypings(pkg: TypingsData): Iterable<TypingsData> {
-        for (const { name, version } of pkg.dependencies) {
+        for (const [name, version] of Object.entries(pkg.dependencies)) {
             const versions = this.data.get(getMangledNameForScopedPackage(name));
             if (versions) {
                 yield versions.get(version);
@@ -308,7 +308,7 @@ export interface TypingsDataRaw extends BaseRaw {
      *
      * These will refer to *package names*, not *folder names*.
      */
-    readonly dependencies: ReadonlyArray<PackageId>;
+    readonly dependencies: { readonly [name: string]: DependencyVersion };
 
     /**
      * Other definitions, that exist in the same typings repo, that the tests, but not the types, of this package depend on.
@@ -513,7 +513,7 @@ export class TypingsData extends PackageBase {
     get globals(): ReadonlyArray<string> { return this.data.globals; }
     get pathMappings(): ReadonlyArray<PathMapping> { return this.data.pathMappings; }
 
-    get dependencies(): ReadonlyArray<PackageId> {
+    get dependencies(): { readonly [name: string]: DependencyVersion } {
         return this.data.dependencies;
     }
 

--- a/src/tester/get-affected-packages.test.ts
+++ b/src/tester/get-affected-packages.test.ts
@@ -3,12 +3,12 @@ import { createTypingsVersionRaw, testo } from "../util/test";
 
 import { getAffectedPackages } from "./get-affected-packages";
 const typesData: TypesDataFile = {
-    jquery: createTypingsVersionRaw("jquery", [], []),
-    known: createTypingsVersionRaw("known", [{ name: "jquery", version: { major: 1 }}], []),
-    "known-test": createTypingsVersionRaw("known-test", [], ["jquery"]),
-    "most-recent": createTypingsVersionRaw("most-recent", [{ name: "jquery", version: "*" }], []),
-    unknown: createTypingsVersionRaw("unknown", [{ name: "COMPLETELY-UNKNOWN", version: { major: 1 }}], []),
-    "unknown-test": createTypingsVersionRaw("unknown-test", [], ["WAT"]),
+    jquery: createTypingsVersionRaw("jquery", {}, []),
+    known: createTypingsVersionRaw("known", { jquery: { major: 1 }}, []),
+    "known-test": createTypingsVersionRaw("known-test", {}, ["jquery"]),
+    "most-recent": createTypingsVersionRaw("most-recent", { jquery: "*" }, []),
+    unknown: createTypingsVersionRaw("unknown", { "COMPLETELY-UNKNOWN": { major: 1 }}, []),
+    "unknown-test": createTypingsVersionRaw("unknown-test", {}, ["WAT"]),
 };
 
 const notNeeded = [

--- a/src/tester/get-affected-packages.ts
+++ b/src/tester/get-affected-packages.ts
@@ -72,8 +72,8 @@ function getReverseDependencies(allPackages: AllPackages, changedPackages: Packa
         }
     }
    for (const typing of allPackages.allTypings()) {
-        for (const dependency of typing.dependencies) {
-            const dependencies = map.get(packageIdToKey(allPackages.tryResolve(dependency)));
+        for (const [name, version] of Object.entries(typing.dependencies)) {
+            const dependencies = map.get(packageIdToKey(allPackages.tryResolve({ name, version })));
             if (dependencies) {
                 dependencies[1].add(typing.id);
             }

--- a/src/tester/test-runner.test.ts
+++ b/src/tester/test-runner.test.ts
@@ -5,12 +5,12 @@ import { createTypingsVersionRaw, testo } from "../util/test";
 import { checkNotNeededPackage, getNotNeededPackages, GitDiff } from "./test-runner";
 
 const typesData: TypesDataFile = {
-    jquery: createTypingsVersionRaw("jquery", [], []),
-    known: createTypingsVersionRaw("known", [{ name: "jquery", version: { major: 1 }}], []),
-    "known-test": createTypingsVersionRaw("known-test", [], ["jquery"]),
-    "most-recent": createTypingsVersionRaw("most-recent", [{ name: "jquery", version: "*" }], []),
-    unknown: createTypingsVersionRaw("unknown", [{ name: "COMPLETELY-UNKNOWN", version: { major: 1 }}], []),
-    "unknown-test": createTypingsVersionRaw("unknown-test", [], ["WAT"]),
+    jquery: createTypingsVersionRaw("jquery", {}, []),
+    known: createTypingsVersionRaw("known", { jquery: { major: 1 }}, []),
+    "known-test": createTypingsVersionRaw("known-test", {}, ["jquery"]),
+    "most-recent": createTypingsVersionRaw("most-recent", { jquery: "*" }, []),
+    unknown: createTypingsVersionRaw("unknown", { "COMPLETELY-UNKNOWN": { major: 1 }}, []),
+    "unknown-test": createTypingsVersionRaw("unknown-test", {}, ["WAT"]),
 };
 
 const jestNotNeeded = [
@@ -31,7 +31,7 @@ testo({
     forgotToDeleteFiles() {
         expect(() =>
             Array.from(getNotNeededPackages(
-                AllPackages.from({ jest: createTypingsVersionRaw("jest", [], []) }, jestNotNeeded),
+                AllPackages.from({ jest: createTypingsVersionRaw("jest", {}, []) }, jestNotNeeded),
                 deleteJestDiffs))).toThrow("Please delete all files in jest");
 
     },

--- a/src/util/test.ts
+++ b/src/util/test.ts
@@ -1,4 +1,4 @@
-import { License, PackageId, TypingsVersionsRaw } from "../lib/packages";
+import { DependencyVersion, License, TypingsVersionsRaw } from "../lib/packages";
 
 export function testo(o: { [s: string]: () => void }) {
     for (const k of Object.keys(o)) {
@@ -7,7 +7,7 @@ export function testo(o: { [s: string]: () => void }) {
 }
 
 export function createTypingsVersionRaw(
-    name: string, dependencies: PackageId[], testDependencies: string[],
+    name: string, dependencies: { readonly [name: string]: DependencyVersion }, testDependencies: string[],
 ): TypingsVersionsRaw {
     return {
         "1.0.0": {


### PR DESCRIPTION
What do you think about changing the `dependencies` data from an array to an object, to prevent duplicates, as in e.g. https://www.npmjs.com/package/@types/jsdom#additional-details

### Before

```JSON
            "dependencies": [
                {
                    "name": "parse5",
                    "version": "*"
                },
                {
                    "name": "tough-cookie",
                    "version": "*"
                },
                {
                    "name": "node",
                    "version": "*"
                },
                {
                    "name": "parse5",
                    "version": "*"
                },
                {
                    "name": "tough-cookie",
                    "version": "*"
                },
                {
                    "name": "node",
                    "version": "*"
                },
                {
                    "name": "parse5",
                    "version": "*"
                },
                {
                    "name": "tough-cookie",
                    "version": "*"
                },
                {
                    "name": "node",
                    "version": "*"
                },
                {
                    "name": "parse5",
                    "version": "*"
                },
                {
                    "name": "tough-cookie",
                    "version": "*"
                },
                {
                    "name": "node",
                    "version": "*"
                },
                {
                    "name": "parse5",
                    "version": "*"
                },
                {
                    "name": "tough-cookie",
                    "version": "*"
                },
                {
                    "name": "node",
                    "version": "*"
                }
            ],
```

### After

```JSON
            "dependencies": {
                "parse5": "*",
                "tough-cookie": "*",
                "node": "*"
            },
```