### PR TITLE
Add cids to dependencies whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -64,6 +64,7 @@ cac
 cassandra-driver
 chalk
 chokidar
+cids
 commander
 connect-mongo
 cordova-plugin-camera


### PR DESCRIPTION
This package is a dependency of `ipld-block`, which I would like to contribute typings for: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44232