### PR TITLE
fix: add `@jest/globals` to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -14,6 +14,7 @@
 @hapi/wreck
 @jest/environment
 @jest/fake-timers
+@jest/globals
 @jest/transform
 @jest/types
 @loadable/component


### PR DESCRIPTION
For https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44365

Not sure if we'll actually land that PR or not, but I think this package can be whitelisted anyways?


Source: https://github.com/facebook/jest/tree/master/packages/jest-globals