### PR TITLE
Keep local references out of testDependencies

### DIFF
--- a/src/lib/module-info.ts
+++ b/src/lib/module-info.ts
@@ -364,14 +364,16 @@ export function getTestDependencies(
             throw new Error(`Test files should not use '<reference path="" />'. '${filePath()}' references '${ref}'.`);
         }
         for (const { fileName: referencedPackage } of typeReferenceDirectives) {
-            if (dependencies.has(referencedPackage)) {
-                throw new Error(
-                    `'${filePath()}' unnecessarily references '${referencedPackage}', which is already referenced in the type definition.`);
+            if (!referencedPackage.startsWith(".")) {
+                if (dependencies.has(referencedPackage)) {
+                    throw new Error(
+                        `'${filePath()}' unnecessarily references '${referencedPackage}', which is already referenced in the type definition.`);
+                }
+                if (referencedPackage === packageName) {
+                    referencesSelf = true;
+                }
+                testDependencies.add(referencedPackage);
             }
-            if (referencedPackage === packageName) {
-                referencesSelf = true;
-            }
-            testDependencies.add(referencedPackage);
         }
         for (const imported of imports(sourceFile)) {
             hasImports = true;


### PR DESCRIPTION
```Diff
diff --git a/data/definitions.json b/data/definitions.json
index a4ad92e..120e306 100644
--- a/data/definitions.json
+++ b/data/definitions.json
@@ -60217,9 +60217,7 @@
             ],
             "license": "MIT",
             "dependencies": [],
-            "testDependencies": [
-                "./addon.pdf"
-            ],
+            "testDependencies": [],
             "pathMappings": [
                 {
                     "packageName": "dwt",
@@ -214895,9 +214893,7 @@
             ],
             "license": "MIT",
             "dependencies": [],
-            "testDependencies": [
-                "../rangy/rangy-classapplier"
-            ],
+            "testDependencies": [],
             "pathMappings": [],
             "packageJsonDependencies": [],
             "contentHash": "d1899dc0e467a283661356bcab863f8ef5a003762dea18e8242d2ab8a60f20c7",
@@ -217965,8 +217961,7 @@
                 "react-addons-transition-group",
                 "react-addons-update",
                 "create-react-class",
-                "react-dom-factories",
-                "../experimental"
+                "react-dom-factories"
             ],
             "pathMappings": [],
             "packageJsonDependencies": [
@@ -268314,12 +268309,7 @@
                     "version": "*"
                 }
             ],
-            "testDependencies": [
-                "../../slickgrid/slick.autotooltips",
-                "../../slickgrid/slick.checkboxselectcolumn",
-                "../../slickgrid/slick.rowselectionmodel",
-                "../../slickgrid/slick.columnpicker"
-            ],
+            "testDependencies": [],
             "pathMappings": [],
             "packageJsonDependencies": [],
             "contentHash": "6cb78ad932a919d0ce2aab13e58b1af628eff8eb3583d59f6a68ad9253e25d5e",
@@ -276550,9 +276540,7 @@
             ],
             "license": "MIT",
             "dependencies": [],
-            "testDependencies": [
-                "../strophe/muc"
-            ],
+            "testDependencies": [],
             "pathMappings": [],
             "packageJsonDependencies": [],
             "contentHash": "65a8cce5c3218653d6542901ffc6dd036f1c5d9da8a4070e9037f13c6f56b56e",
@@ -276585,9 +276573,7 @@
             ],
             "license": "MIT",
             "dependencies": [],
-            "testDependencies": [
-                "../strophe.js/muc"
-            ],
+            "testDependencies": [],
             "pathMappings": [],
             "packageJsonDependencies": [],
             "contentHash": "a2fc0bf002da5df42cd95a62b2f4c1575ebd015e39540f6c86337b4271f00cdf",
@@ -298117,7 +298103,6 @@
             "license": "MIT",
             "dependencies": [],
             "testDependencies": [
-                "../waypoints/jquery",
                 "jquery"
             ],
             "pathMappings": [],
@@ -299177,9 +299162,7 @@
                     "version": "*"
                 }
             ],
-            "testDependencies": [
-                "../next"
-            ],
+            "testDependencies": [],
             "pathMappings": [],
             "packageJsonDependencies": [
                 {
```