### PR TITLE
Make .allDependencyTypings() respect path mappings

### DIFF
--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -124,7 +124,8 @@ export class AllPackages {
         for (const name of pkg.testDependencies) {
             const versions = this.data.get(getMangledNameForScopedPackage(name));
             if (versions) {
-                yield versions.getLatest();
+                const version = pkg.pathMappings.find(({ packageName }) => packageName === name)?.version;
+                yield version ? versions.get(version) : versions.getLatest();
             }
         }
     }


### PR DESCRIPTION
If package A has a test dependency on B (because A's tests import B) and A has a path mapping B -> B/v#, then the compiler will use older-version B/v#, but `AllPackages.allDependencyTypings()` currently returns only the latest-versions of test dependencies: https://github.com/microsoft/types-publisher/blob/54bd71c9fed3c13fefed2284c3fad62bfac66bdd/src/lib/packages.ts#L124-L127

This comes up in `check-parse-results.ts` `checkPathMappings()`, which checks for unused path mappings: All of a package's path mappings must be accounted for by a transitive dependency.

If A has a test dependency on B and a path mapping B -> B/v#, and B/v# in turn depends on C/v#, then A needs path mapping C -> C/v# or A's tests will combine possibly-incompatible packages B/v# and C-latest. But the compiler and `checkPathMappings()` currently use different versions of B: Unless B-latest also depends on C/v#, `checkPathMappings()` will complain that A's C -> C/v# path mapping is unused. Then A can't get past the CI automation: Its tests fail without the path mapping and `checkPathMappings()` fails with it.

`checkPathMappings()` already handles the case that A has a *regular* dependency on B. It respects the path mapping and uses the older version B/v#, same as the compiler. This is implemented in `definition-parser.ts` `calculateDependencies()`: https://github.com/microsoft/types-publisher/blob/54bd71c9fed3c13fefed2284c3fad62bfac66bdd/src/lib/definition-parser.ts#L376

This PR applies the same logic to `AllPackages.allDependencyTypings()` and test dependencies.