### PR TITLE
Non-relative reference in typesVersions parent

### DIFF
--- a/src/lib/module-info.ts
+++ b/src/lib/module-info.ts
@@ -256,7 +256,10 @@ function findReferencedFiles(src: ts.SourceFile, packageName: string, subDirecto
 
     /** boring/foo -> ./foo when subDirectory === '.'; ../foo when it's === 'x'; ../../foo when it's 'x/y' */
     function convertToRelativeReference(name: string) {
-        const relative = "." + "/..".repeat(subDirectory === "." ? 0 : subDirectory.split("/").length);
+        let relative = "." + "/..".repeat(subDirectory === "." ? 0 : subDirectory.split("/").length);
+        if (baseDirectory && subDirectory.startsWith("..")) {
+            relative = relative.slice(0, -2) + baseDirectory;
+        }
         return relative + name.slice(packageName.length);
     }
 }


### PR DESCRIPTION
### Scenario 1

Currently, if you `import * as promises from "fs/promises"` in `types/fs/ts3.2/index.d.ts` (non-relative self-reference in a typesVersions directory),
- `baseDirectory` is `ts3.2`
- `subDirectory` is `.`
- `convertToRelativeReference()` returns `./promises` (the `subDirectory === "."` case), which would be `types/fs/ts3.2/promises.d.ts` :heavy_check_mark:
https://github.com/microsoft/types-publisher/blob/54bd71c9fed3c13fefed2284c3fad62bfac66bdd/src/lib/module-info.ts#L257-L261

### Scenario 2

However files in typesVersions directories are allowed to reference files in the parent directory, so if you `import * as promises from "fs/promises"` in `types/fs/index.d.ts` and `/// <reference path="../index.d.ts" />` in `types/fs/ts3.2/index.d.ts` (non-relative self-reference in a typesVersions *parent directory*),
- `baseDirectory` is still `ts3.2`
- `subDirectory` is `..`
- `convertToRelativeReference()` returns `../promises` (the `subDirectory.split("/").length` case), which would be `types/promises.d.ts` or something :x:

That triggers
```
Error: ../index.d.ts: Definitions must use global references to other packages, not parent ("../xxx") references.(Based on reference './../promises')
```
https://github.com/microsoft/types-publisher/blob/54bd71c9fed3c13fefed2284c3fad62bfac66bdd/src/lib/module-info.ts#L237-L251

### Proposed Change

If we're in a typesVersions parent directory (`baseDirectory && subDirectory.startsWith("..")`) this change adds the `baseDirectory` to the relative reference, so in scenario 2, `convertToRelativeReference()` returns `./ts3.2/promises`, which would be `types/fs/ts3.2/promises.d.ts`, the same as in scenario 1 :heavy_check_mark: