### PR TITLE
Replace upstreamed dependency (cash-dom) with legacy dependency (@types/cash)

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -24,6 +24,7 @@
 @storybook/addons
 @storybook/react
 @types/base-x
+@types/cash
 @types/expect
 @types/firebase
 @types/highcharts
@@ -64,7 +65,6 @@ bignumber.js
 bookshelf
 broadcast-channel
 cac
-cash-dom
 cassandra-driver
 chalk
 chokidar


### PR DESCRIPTION
This is a continuation of/replacement for #778, implemented as part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44533: use the legacy cash-dom typings (@types/cash) for its sole dependent (materialize-css) to minimize compatibility issues/breakage.