### PR TITLE
feat(mini-html-webpack-plugin): whitelist package

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -135,6 +135,7 @@ knockout
 magic-string
 mali
 meteor-typings
+mini-html-webpack-plugin
 moment
 monaco-editor
 moment-range


### PR DESCRIPTION
Part of WebPack ecosystem it now ships its own definitions:
https://github.com/styleguidist/mini-html-webpack-plugin/blob/master/package.json#L6

Thanks!