### PR TITLE
Add gl-matrix

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -100,6 +100,7 @@ fastify
 final-form
 flatpickr
 form-data
+gl-matrix
 glaze
 globby
 google-auth-library


### PR DESCRIPTION
This is in prep for removing `@types/gl-matrix` from DefinitelyTyped now that [gl-matrix](https://github.com/toji/gl-matrix) ships with its own types.