### PR TITLE
Add @wordpress/element to whitelist

### DIFF
--- a/dependenciesWhitelist.txt
+++ b/dependenciesWhitelist.txt
@@ -43,6 +43,7 @@
 @types/wonder-frp
 @uirouter/angularjs
 @vue/test-utils
+@wordpress/element
 abort-controller
 actions-on-google
 activex-helpers


### PR DESCRIPTION
As of 2.14.0 @wordpress/element bundles types:

https://unpkg.com/browse/@wordpress/element@2.14.0/

These types should be used to replace the wordpress__element types in
DefinitelyTyped.

I'm creating this PR at the prompt of a DefinitelyTyped error message:

```
If this is an external library that provides typings,  please make a pull request to types-publisher adding it to `dependenciesWhitelist.txt`.
```